### PR TITLE
Add .gitattributes for Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+*.sh text eol=lf
+*.cfg text eol=lf
+*.patch text eol=lf
+*.conf text eol=lf
+*.crt text eol=lf
+*.key text eol=lf


### PR DESCRIPTION
This avoids creating corrupt images from Windows builds due to CRLF
files in the wrong places (like ssl keys, scripts, etc)