### PR TITLE
Use Ember Fedora Adapter and fix https behavior

### DIFF
--- a/.env
+++ b/.env
@@ -11,9 +11,9 @@ SUBMISSION_GIT_BRANCH=demo
 # Ember app config
 EMBER_PORT=81
 EMBER_GIT_REPO=https://github.com/markpatton/pass-ember
-EMBER_GIT_BRANCH=fedora_jsonld
-PASS_FEDORA_PORT=443
-PASS_FEDORA_PATH=fcrepo/rest
+EMBER_GIT_BRANCH=fedora_adapter
+FEDORA_ADAPTER_BASE=https://pass/fcrepo/rest
+FEDORA_ADAPTER_CONTEXT=https://oa-pass.github.io/pass-data-model/src/main/resources/context.jsonld
 
 # Fedora config
 FCREPO_PORT=8080

--- a/fcrepo/4.7.5-demo/Dockerfile
+++ b/fcrepo/4.7.5-demo/Dockerfile
@@ -7,10 +7,10 @@ FCREPO_JMS_PORT=61616 \
 FCREPO_STOMP_PORT=61613 \
 FCREPO_CONTEXT_PATH=/fcrepo \
 FCREPO_LOG_LEVEL=INFO \
-FCREPO_MODESHAPE_CONFIGURATION=classpath:/config/servlet-auth/repository.json \
 ACTIVEMQ_BROKER_URI=tcp://localhost:61616 \
 FCREPO_ACTIVEMQ_CONFIGURATION=classpath:/config/activemq.xml \
 FCREPO_SPRING_CONFIGURATION=classpath:/spring/master.xml \
+FCREPO_MODESHAPE_CONFIGURATION=classpath:/pass-repository.json \
 SLF4J_VERSION=1.7.25 \
 DEBUG_PORT=5006 \
 DEBUG_ARG="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5006"
@@ -20,6 +20,7 @@ EXPOSE ${FCREPO_PORT}
 
 COPY bin/* /bin/
 COPY conf/* ${CATALINA_HOME}/conf/
+COPY lib/* ${CATALINA_HOME}/lib/
 COPY tomcat-bin/* ${CATALINA_HOME}/bin/
 
 RUN apk update && \

--- a/fcrepo/4.7.5-demo/Dockerfile
+++ b/fcrepo/4.7.5-demo/Dockerfile
@@ -33,8 +33,8 @@ RUN apk update && \
         | sha1sum -c -  && \
     echo "org.apache.catalina.webresources.Cache.level = SEVERE" \
       >> ${CATALINA_HOME}/conf/logging.properties && \
-    wget -O ${CATALINA_HOME}/lib/jsonld-addon-filters-0.0.1-SNAPSHOT-shaded.jar \
-        https://github.com/DataConservancy/fcrepo-jsonld/releases/download/0.0.1-SNAPSHOT/jsonld-addon-filters-0.0.1-SNAPSHOT-shaded.jar && \
+    wget -O ${CATALINA_HOME}/lib/jsonld-addon-filters-0.0.2-SNAPSHOT-shaded.jar \
+        https://github.com/DataConservancy/fcrepo-jsonld/releases/download/0.0.2-SNAPSHOT/jsonld-addon-filters-0.0.2-SNAPSHOT-shaded.jar && \
     mkdir ${CATALINA_HOME}/webapps/fcrepo && \
     unzip ${CATALINA_HOME}/webapps/fcrepo.war -d ${CATALINA_HOME}/webapps/fcrepo  && \
     rm ${CATALINA_HOME}/webapps/fcrepo.war && \

--- a/fcrepo/4.7.5-demo/WEB-INF/web.xml
+++ b/fcrepo/4.7.5-demo/WEB-INF/web.xml
@@ -43,7 +43,7 @@
 
     <init-param>
       <param-name>cors.allowed.origins</param-name>
-      <param-value>*</param-value>
+      <param-value>https://pass</param-value>
     </init-param>
 
     <init-param>
@@ -94,7 +94,7 @@
 
   <security-constraint>
     <web-resource-collection>
-      <url-pattern>/</url-pattern>
+      <url-pattern>/*</url-pattern>
       <http-method-omission>OPTIONS</http-method-omission>
     </web-resource-collection>
     <auth-constraint>

--- a/fcrepo/4.7.5-demo/WEB-INF/web.xml
+++ b/fcrepo/4.7.5-demo/WEB-INF/web.xml
@@ -43,7 +43,7 @@
 
     <init-param>
       <param-name>cors.allowed.origins</param-name>
-      <param-value>https://pass</param-value>
+      <param-value>*</param-value>
     </init-param>
 
     <init-param>
@@ -94,7 +94,7 @@
 
   <security-constraint>
     <web-resource-collection>
-      <url-pattern>/*</url-pattern>
+      <url-pattern>/</url-pattern>
       <http-method-omission>OPTIONS</http-method-omission>
     </web-resource-collection>
     <auth-constraint>

--- a/fcrepo/4.7.5-demo/conf/web.xml
+++ b/fcrepo/4.7.5-demo/conf/web.xml
@@ -4707,6 +4707,12 @@
       <filter-class>org.dataconservancy.fcrepo.jsonld.deserialize.DeserializationFilter</filter-class>
       <async-supported>true</async-supported>
     </filter>
+
+    <filter>
+      <filter-name>uri-protocol-filter</filter-name>
+      <filter-class>org.dataconservancy.fcrepo.jsonld.request.UriProtocolFilter</filter-class>
+      <async-supported>true</async-supported>
+    </filter>
     
     <filter-mapping>
       <filter-name>jsonld-compaction-filter</filter-name>
@@ -4715,6 +4721,11 @@
     
     <filter-mapping>
       <filter-name>jsonld-deserialization-filter</filter-name>
+      <url-pattern>/*</url-pattern>
+    </filter-mapping>
+
+    <filter-mapping>
+      <filter-name>uri-protocol-filter</filter-name>
       <url-pattern>/*</url-pattern>
     </filter-mapping>
 

--- a/fcrepo/4.7.5-demo/lib/pass-node-types.cnd
+++ b/fcrepo/4.7.5-demo/lib/pass-node-types.cnd
@@ -1,0 +1,103 @@
+/*
+ * JCR node types for use with Fedora
+ */
+<jcr = 'http://www.jcp.org/jcr/1.0'>
+<nt = 'http://www.jcp.org/jcr/nt/1.0'>
+<mix = 'http://www.jcp.org/jcr/mix/1.0'>
+<image='http://www.modeshape.org/images/1.0'>
+
+/*
+ * Friend-of-a-Friend
+ */
+<foaf = 'http://xmlns.com/foaf/0.1/'>
+
+/*
+ * Dublin Core. See:
+ * 
+ * http://dublincore.org/documents/dcmi-namespace/
+ */
+<dc = 'http://purl.org/dc/elements/1.1/'>
+
+/*
+ * Generic Fedora namespace
+ */
+<fedora = 'http://fedora.info/definitions/v4/repository#'>
+<rdf = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
+<rdfs = 'http://www.w3.org/2000/01/rdf-schema#'>
+<premis = 'http://www.loc.gov/premis/rdf/v1#'>
+<ldp = 'http://www.w3.org/ns/ldp#'>
+<ebucore = 'http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#'>
+
+/*
+ * A fedora namespace for properties a user may set on a node that may
+ * enable or disable a fedora-specific behavior of that node.
+ */
+<fedoraconfig = 'http://fedora.info/definitions/v4/config#'>
+
+<test = 'info:fedora/test/'>
+/*
+ * Any Fedora resource.
+ */
+[fedora:Resource] > mix:created, mix:lastModified, mix:referenceable mixin
+  - rdf:type (URI) multiple
+  - fedora:lastModified (DATE)
+  - fedora:created (DATE)
+  - fedora:lastModifiedBy (STRING)
+  - fedora:createdBy (STRING)
+  - * (undefined) multiple
+  - * (undefined)
+
+/*
+ * A Fedora object.
+ */
+[fedora:Container] > fedora:Resource mixin
+  - ldp:membershipResource (REFERENCE)
+  - ldp:hasMemberRelation (URI)
+  - ldp:isMemberOfRelation (URI)
+  - ldp:insertedContentRelation (URI)
+
+[ldp:BasicContainer] > fedora:Container mixin
+
+[ldp:DirectContainer] > fedora:Container  mixin
+
+[ldp:IndirectContainer] > fedora:Container  mixin
+
+/*
+ * A Fedora datastream.
+ */
+[fedora:NonRdfSourceDescription] > fedora:Resource mixin
+
+/*
+ * Some content that can have a checksum
+ */
+[fedora:Binary] > fedora:Resource mixin
+  - ebucore:filename (STRING)
+  - ebucore:hasMimeType (STRING)
+  - premis:hasSize (LONG) COPY
+  - premis:hasMessageDigest (URI) COPY multiple
+
+[fedora:Skolem] > mix:referenceable mixin
+  - fedora:lastModified (DATE)
+
+[fedora:Pairtree] mixin
+
+[fedora:Tombstone] > nt:hierarchyNode
+
+/*
+ * PASS types
+ */
+ 
+ <pass = 'http://example.org/pass/'>
+
+[pass:Deposit] > fedora:Container mixin
+[pass:Funder] > fedora:Container mixin
+[pass:Grant] > fedora:Container mixin
+[pass:Identifier] > fedora:Container mixin
+[pass:Journal] > fedora:Container mixin
+[pass:Person] > fedora:Container mixin
+[pass:Policy] > fedora:Container mixin
+[pass:Publisher] > fedora:Container mixin
+[pass:Repository] > fedora:Container mixin
+[pass:Submission] > fedora:Container mixin
+[pass:User] > fedora:Container mixin
+[pass:Workflow] > fedora:Container mixin

--- a/fcrepo/4.7.5-demo/lib/pass-repository.json
+++ b/fcrepo/4.7.5-demo/lib/pass-repository.json
@@ -1,0 +1,36 @@
+{
+    "name" : "repo",
+    "jndiName" : "",
+    "workspaces" : {
+        "predefined" : ["default"],
+        "default" : "default",
+        "allowCreation" : true,
+        "cacheSize" : 10000
+    },
+    "storage" : {
+        "persistence": {
+            "type": "file",
+            "path" : "${fcrepo.object.directory:target/objects}"
+        },
+        "binaryStorage" : {
+            "type" : "file",
+            "directory" : "${fcrepo.binary.directory:target/binaries}",
+            "minimumBinarySizeInBytes" : 4096
+        }
+    },
+    "security" : {
+        "anonymous" : {
+            "roles" : ["readonly","readwrite","admin"],
+            "useOnFailedLogin" : false
+        },
+        "providers" : [
+            { "classname" : "org.fcrepo.auth.common.ServletContainerAuthenticationProvider" }
+        ]
+    },
+    "garbageCollection" : {
+        "threadPool" : "modeshape-gc",
+        "initialTime" : "00:00",
+        "intervalInHours" : 24
+    },
+    "node-types" : ["pass-node-types.cnd"]
+}

--- a/httpd-proxy/etc-httpd/conf.d/httpd.conf
+++ b/httpd-proxy/etc-httpd/conf.d/httpd.conf
@@ -38,18 +38,16 @@ EECDH EDH+aRSA !aNULL !eNULL !LOW !3DES !MD5 !EXP !PSK !SRP !DSS !RC4"
     RequestHeader set REMOTE-USER %{REMOTE_USER}s
     # Upgrade insecure requests, as an alternative to mod_substitute
     # for http -> https url rewriting in response bodies.
-    Header set Strict-Transport-Security "max-age=300"
-    Header set Content-Security-Policy: upgrade-insecure-requests
+    #Header set Strict-Transport-Security "max-age=300"
+    #Header set Content-Security-Policy: upgrade-insecure-requests
 
     Header set Access-Control-Max-Age "300"
     # could be 'localhost', <ip-of-docker-machine>, '</etc/hosts entry>'
-    Header set Access-Control-Allow-Origin "https://pass"
+    Header set Access-Control-Allow-Origin "*"
     # allow cookies to be sent cross origin
     Header set Access-Control-Allow-Credentials "true"
     Header merge Access-Control-Allow-Methods "PUT, OPTIONS"
     Header merge Access-Control-Expose-Headers "authorization"
-
-    Header edit Location ^http: https:
 
     #Map /idp to Tomcat
     ProxyPass /idp https://idp:4443/idp
@@ -59,10 +57,10 @@ EECDH EDH+aRSA !aNULL !eNULL !LOW !3DES !MD5 !EXP !PSK !SRP !DSS !RC4"
     ProxyPassReverse /Shibboleth.sso http://sp/Shibboleth.sso
 
     ProxyPass /fcrepo http://sp/fcrepo
-    ProxyPassReverse /fcrepo https://sp/fcrepo
+    ProxyPassReverse /fcrepo http://sp/fcrepo
 
     # Proxying the root url should always be listed last
-    ProxyPassReverse / https://sp/
+    ProxyPassReverse / http://sp/
     ProxyPass / http://sp/
 
 </VirtualHost>

--- a/httpd-proxy/etc-httpd/conf.d/httpd.conf
+++ b/httpd-proxy/etc-httpd/conf.d/httpd.conf
@@ -43,11 +43,13 @@ EECDH EDH+aRSA !aNULL !eNULL !LOW !3DES !MD5 !EXP !PSK !SRP !DSS !RC4"
 
     Header set Access-Control-Max-Age "300"
     # could be 'localhost', <ip-of-docker-machine>, '</etc/hosts entry>'
-    Header set Access-Control-Allow-Origin "*"
+    Header set Access-Control-Allow-Origin "https://pass"
     # allow cookies to be sent cross origin
     Header set Access-Control-Allow-Credentials "true"
     Header merge Access-Control-Allow-Methods "PUT, OPTIONS"
     Header merge Access-Control-Expose-Headers "authorization"
+
+    Header edit Location ^http: https:
 
     #Map /idp to Tomcat
     ProxyPass /idp https://idp:4443/idp
@@ -57,10 +59,10 @@ EECDH EDH+aRSA !aNULL !eNULL !LOW !3DES !MD5 !EXP !PSK !SRP !DSS !RC4"
     ProxyPassReverse /Shibboleth.sso http://sp/Shibboleth.sso
 
     ProxyPass /fcrepo http://sp/fcrepo
-    ProxyPassReverse /fcrepo http://sp/fcrepo
+    ProxyPassReverse /fcrepo https://sp/fcrepo
 
     # Proxying the root url should always be listed last
-    ProxyPassReverse / http://sp/
+    ProxyPassReverse / https://sp/
     ProxyPass / http://sp/
 
 </VirtualHost>

--- a/httpd-proxy/etc-httpd/conf.d/httpd.conf
+++ b/httpd-proxy/etc-httpd/conf.d/httpd.conf
@@ -36,9 +36,11 @@ EECDH EDH+aRSA !aNULL !eNULL !LOW !3DES !MD5 !EXP !PSK !SRP !DSS !RC4"
     ProxyPreserveHost on
     RequestHeader set X-Forwarded-Proto "https" env=HTTPS
     RequestHeader set REMOTE-USER %{REMOTE_USER}s
-    #not needed at the moment, but may be useful to replace use of mod_substitute
+    # Upgrade insecure requests, as an alternative to mod_substitute
     # for http -> https url rewriting in response bodies.
     Header set Strict-Transport-Security "max-age=300"
+    Header set Content-Security-Policy: upgrade-insecure-requests
+
     Header set Access-Control-Max-Age "300"
     # could be 'localhost', <ip-of-docker-machine>, '</etc/hosts entry>'
     Header set Access-Control-Allow-Origin "*"

--- a/sp/2.6.1/etc-httpd/conf.d/sp.conf
+++ b/sp/2.6.1/etc-httpd/conf.d/sp.conf
@@ -16,23 +16,13 @@ LoadModule proxy_ajp_module modules/mod_proxy_ajp.so
         # Pass attributes received from Shib as HTTP headers to Fedora
         # When this is enabled, the SP accuses the UA of spoofing REMOTE_USER (as set in the httpd-proxy)
         #ShibUseHeaders On
-        <LimitExcept OPTIONS>
-            require shib-session
-        </LimitExcept>
         require shib-session
-        # Use HSTS instead
-        AddOutputFilterByType SUBSTITUTE text/html
-        AddOutputFilterByType SUBSTITUTE application/ld+json
-        AddOutputFilterByType SUBSTITUTE text/turtle
-        Substitute "s|http://pass|https://pass|n"
     </Location>
 
     <Location />
         AuthType shibboleth
         ShibRequestSetting requireSession 1
-        <LimitExcept OPTIONS>
-            require shib-session
-        </LimitExcept>
+        require shib-session
     </Location>
 
     ProxyPreserveHost on

--- a/sp/2.6.1/etc-httpd/conf.d/sp.conf
+++ b/sp/2.6.1/etc-httpd/conf.d/sp.conf
@@ -16,16 +16,23 @@ LoadModule proxy_ajp_module modules/mod_proxy_ajp.so
         # Pass attributes received from Shib as HTTP headers to Fedora
         # When this is enabled, the SP accuses the UA of spoofing REMOTE_USER (as set in the httpd-proxy)
         #ShibUseHeaders On
+        <LimitExcept OPTIONS>
+            require shib-session
+        </LimitExcept>
         require shib-session
         # Use HSTS instead
-        #AddOutputFilterByType SUBSTITUTE text/html
-        #Substitute "s|http://pass|https://pass|n"
+        AddOutputFilterByType SUBSTITUTE text/html
+        AddOutputFilterByType SUBSTITUTE application/ld+json
+        AddOutputFilterByType SUBSTITUTE text/turtle
+        Substitute "s|http://pass|https://pass|n"
     </Location>
 
     <Location />
         AuthType shibboleth
         ShibRequestSetting requireSession 1
-        require shib-session
+        <LimitExcept OPTIONS>
+            require shib-session
+        </LimitExcept>
     </Location>
 
     ProxyPreserveHost on


### PR DESCRIPTION
## Overview
* Uses @markpatton branch of the Ember Fedora adapter, as it is not yet merged into master.  This branch performs authentication for XHR requests from Ember by passing along the shib cookies needed by the SP
* Adds a `.cnd` file to pre-define PASS types and namespaces in Fedora.  This resolves the race condition resulting in `400` errors
* Adds a servlet filter to allow Fedora to respond with `https` URIs whenever it encounters `X-Forwarded-Proto: https`
* Disables HSTS, as it is no longer required 

## Known Issues

The grants table seems to be disabled in the latest Ember Fedora Adapter, due to the lack of query being implemented

## How to Test

* Re-build all images `docker-compose build`
* Make sure all containers are destroyed `docker-compose down`
* Read the existing instructions (e.g setting the `pass` host locally) and start `docker-compose up -d`
* Go to `https://pass`.  This will do shib login, then load the ember app.  
   * At the shib login page, use one of the normal pre-baked users and passwords
   * At the secondary (redundant, will soon be removed) login screen in Ember, type in a valid user (e.g. `agudzun`) with an arbitrary password
* It should load correctly and bring you to the login screen.  Play around, excepting the above known issues with the grants table.

## Interested Parties
@emetsger @markpatton, maybe @htpvu 