### PR TITLE
Allow Location header to be used by Fedora clients.

### DIFF
--- a/fcrepo/4.7.5-demo/WEB-INF/web.xml
+++ b/fcrepo/4.7.5-demo/WEB-INF/web.xml
@@ -58,7 +58,7 @@
 
     <init-param>
       <param-name>cors.exposed.headers</param-name>
-      <param-value>Access-Control-Allow-Origin,Access-Control-Allow-Credentials</param-value>
+      <param-value>Access-Control-Allow-Origin,Access-Control-Allow-Credentials,Location</param-value>
     </init-param>
 
     <init-param>


### PR DESCRIPTION
This is needed so we can change the adapter from using the POST response to get an id to using the Location header.