### PR TITLE
Provides DSPace and Postgres images for PASS integration.

### DIFF
--- a/.env
+++ b/.env
@@ -34,3 +34,10 @@ COMPACTION_PRELOAD_FILE_PASS_STATIC=/usr/local/tomcat/lib/context.jsonld
 # Uncomment to have Tomcat debug authentication/authorization for each request
 #FCREPO_TOMCAT_AUTH_LOGGING_ENABLED=true
 #
+
+# DSpace config
+DSPACE_HOST=localhost
+DSPACE_PORT=8181
+
+# Postgres config
+POSTGRES_DB_PORT=6543

--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ To configure the Docker images, open up the `.env` file and make any necessary c
   - FCREPO_TOMCAT_REQUEST_DUMPER_ENABLED: if set to `true`, instructs Tomcat to dump the headers for each request/response
   - FCREPO_TOMCAT_AUTH_LOGGING_ENABLED: if set to `true`, instructs Tomcat to log additional information regarding authentication and authorization
 
+### DSpace-related variables
+
+  - DSPACE_HOST: the host name DSpace will use when generating HTTP responses, defaults to `localhost` (`docker-machine` users _must_ set this to the IP address of their docker-machine)
+  - DSPACE_PORT: the port that DSpace and its applications are exposed on, defaults to port `8181`
+  
+### Postgres-related variables
+
+  - POSTGRES_DB_PORT: the port that the Postgres database is exposed on, defaults to `6543`
+     
 <h2><a id="build" href="#build">Building the Docker Images</a> (optional)</h2>
 
 If the images deployed to Docker Hub are up-to-date, then you do not need to build the images.
@@ -81,6 +90,15 @@ After starting the demo with the defaults, the following services should work.
   - HTTP POST submission trigger: `localhost:8081`
   - Fedora: `http://localhost:8080/fcrepo/rest`
   - Same Fedora instance behind a Shibboleth SP: `https://localhost/fcrepo/rest`
+  - DSpace repository, exposed at port `8181`: `http://localhost:8181/xmlui`
+      - Login with username `dspace-admin@oapass.org`, password `foobar`
+      - Not behind the Shibboleth SP
+  - DSpace SWORD v2 endpoint: `http://localhost:8181/swordv2/servicedocument`
+      - Protected by HTTP basic auth
+      - Authenticate with username `dspace-admin@oapass.org`, password `foobar`
+      - Not behind the Shibboleth SP
+  - Postgres database, exposed at port `6543`
+      - DSpace database name `dspace`, username `dspace`, no password
 
 
 >(**N.B.** `docker-machine` users will need to substitute the IP address of their Docker machine in place of `localhost`)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,6 +113,26 @@ services:
     secrets:
      - source: sp_key
 
+  dspace:
+    build: ./dspace/6.2
+    image: oapass/dspace
+    container_name: dspace
+    env_file: .env
+    ports:
+      - "${DSPACE_PORT}:${DSPACE_PORT}"
+    networks:
+      - back
+
+  postgres:
+    build: ./postgres/10.3
+    image: oapass/postgres
+    container_name: postgres
+    env_file: .env
+    ports:
+      - "${POSTGRES_DB_PORT}:${POSTGRES_DB_PORT}"
+    networks:
+      - back
+
 networks:
   front:
     driver: bridge

--- a/dspace/6.2/Dockerfile
+++ b/dspace/6.2/Dockerfile
@@ -44,7 +44,8 @@ RUN mkdir ${DSPACE_BUILD_DIR} && \
         apache-ant \
         openjdk8 \
         git && \
-    rm -rf /var/cache/apk
+    rm -rf /var/cache/apk && \
+    rm -rf ~/.m2
 
 ADD wait-and-init-db.sh /wait-and-init-db.sh
 

--- a/dspace/6.2/Dockerfile
+++ b/dspace/6.2/Dockerfile
@@ -1,0 +1,62 @@
+FROM jetty:9.4.7-jre8-alpine
+
+ARG DSPACE_BUILD_DIR=/dspace-build
+ARG DSPACE_INSTALL_DIR=/dspace
+ARG DSPACE_USER=jetty
+ARG DSPACE_GIT_REPO=${DSPACE_GIT_REPO:-https://github.com/DSpace/DSpace}
+ARG DSPACE_GIT_BRANCH=${DSPACE_GIT_BRANCH:-dspace-6.2}
+
+ENV DSPACE_HOST=${DSPACE_HOST:-localhost} \
+    DSPACE_PORT=${DSPACE_PORT:-8181} \
+    DSPACE_DB_HOST=${DSPACE_DB_HOST:-postgres} \
+    POSTGRES_DB_PORT=${POSTGRES_DB_PORT:-5432} \
+    DSPACE_DB_NAME=${DSPACE_DB_NAME:-dspace} \
+    DSPACE_DB_USER=${DSPACE_DB_USER:-dspace} \
+    DSPACE_DB_PASS=${DSPACE_DB_PASS:-""} \
+    DSPACE_INSTALL_DIR=${DSPACE_INSTALL_DIR:-/dspace}
+
+USER root
+
+RUN mkdir ${DSPACE_BUILD_DIR} && \
+    cd ${DSPACE_BUILD_DIR} && \
+    apk --update --no-cache add \
+            openjdk8 \
+            maven \
+            git \
+            apache-ant \
+            postgresql-client && \
+    git clone ${DSPACE_GIT_REPO}  && \
+    cd `basename ${DSPACE_GIT_REPO}` && \
+    git checkout -b ${DSPACE_GIT_BRANCH} ${DSPACE_GIT_BRANCH} && \
+    mvn package && \
+    cd dspace/target/dspace-installer && \
+    sed -e "s:^[ ]*depends=\"init_installation,init_configs,test_database,install_code\":depends=\"init_installation,init_configs,install_code\":" -i build.xml && \
+    ant fresh_install && \
+    grep ${DSPACE_USER} /etc/passwd || adduser -D ${DSPACE_USER} ; \
+    mkdir -p ${DSPACE_INSTALL_DIR} && \
+    cp -r ${DSPACE_INSTALL_DIR}/webapps/xmlui/ /var/lib/jetty/webapps && \
+    cp -r ${DSPACE_INSTALL_DIR}/webapps/swordv2/ /var/lib/jetty/webapps && \
+    cp -r ${DSPACE_INSTALL_DIR}/webapps/solr/ /var/lib/jetty/webapps && \
+    chown -R ${DSPACE_USER} ${DSPACE_INSTALL_DIR} && \
+    chown -R jetty /var/lib/jetty/webapps/* && \
+    cd / && \
+    rm -rf ${DSPACE_BUILD_DIR} && \
+    apk del maven \
+        apache-ant \
+        openjdk8 \
+        git && \
+    rm -rf /var/cache/apk
+
+ADD wait-and-init-db.sh /wait-and-init-db.sh
+
+ADD import.xml /import.xml
+
+RUN chown jetty /wait-and-init-db.sh && chmod 550 /wait-and-init-db.sh && chown ${DSPACE_USER} /import.xml
+
+USER jetty
+
+WORKDIR /var/lib/jetty
+
+CMD ["/wait-and-init-db.sh"]
+
+EXPOSE ${DSPACE_PORT}

--- a/dspace/6.2/Dockerfile
+++ b/dspace/6.2/Dockerfile
@@ -36,7 +36,6 @@ RUN mkdir ${DSPACE_BUILD_DIR} && \
     mkdir -p ${DSPACE_INSTALL_DIR} && \
     cp -r ${DSPACE_INSTALL_DIR}/webapps/xmlui/ /var/lib/jetty/webapps && \
     cp -r ${DSPACE_INSTALL_DIR}/webapps/swordv2/ /var/lib/jetty/webapps && \
-    cp -r ${DSPACE_INSTALL_DIR}/webapps/solr/ /var/lib/jetty/webapps && \
     chown -R ${DSPACE_USER} ${DSPACE_INSTALL_DIR} && \
     chown -R jetty /var/lib/jetty/webapps/* && \
     cd / && \

--- a/dspace/6.2/import.xml
+++ b/dspace/6.2/import.xml
@@ -1,0 +1,25 @@
+<!--
+  ~ Copyright 2018 Johns Hopkins University
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<import_structure>
+  <community>
+    <name>Community One</name>
+    <description>A Community used for testing, populated by Docker</description>
+    <collection>
+      <name>Collection One</name>
+      <description>A Collection used for testing, populated by Docker</description>
+    </collection>
+  </community>
+</import_structure>

--- a/dspace/6.2/wait-and-init-db.sh
+++ b/dspace/6.2/wait-and-init-db.sh
@@ -10,7 +10,7 @@ function verify_db() {
 
 # performs the supplied query against the DSpace database
 function perform_query() {
-    psql -c "$1" -h ${POSTGRES_DB_PORT} -p ${POSTGRES_DB_PORT} -w ${DSPACE_DB_NAME} ${DSPACE_DB_USER}
+    psql -c "$1" -h ${DSPACE_DB_HOST} -p ${POSTGRES_DB_PORT} -w ${DSPACE_DB_NAME} ${DSPACE_DB_USER}
 }
 
 # blocks until the database is available, or returns 1 to indicate failure

--- a/dspace/6.2/wait-and-init-db.sh
+++ b/dspace/6.2/wait-and-init-db.sh
@@ -1,0 +1,123 @@
+#!/bin/ash
+#set -xv
+
+DSPACE_ADMIN_USERNAME=dspace-admin@oapass.org
+
+# insure the database is up and simple query can be executed
+function verify_db() {
+    perform_query "SELECT 1" 2>&1 /dev/null
+}
+
+# performs the supplied query against the DSpace database
+function perform_query() {
+    psql -c "$1" -h ${POSTGRES_DB_PORT} -p ${POSTGRES_DB_PORT} -w ${DSPACE_DB_NAME} ${DSPACE_DB_USER}
+}
+
+# blocks until the database is available, or returns 1 to indicate failure
+function wait_for_db() {
+    local RETRY_S=$1
+    local LIMIT_S=$2
+    local START_S=`date +%s`
+
+    while [ $(expr `date +%s` - ${START_S}) -lt ${LIMIT_S} ] ;
+    do
+        (>&2 echo ">>> Waiting for database ...")
+        verify_db
+        if [ $? == 0 ] ;
+        then
+            (>&2 echo ">>> Database is up!")
+            return 0;
+        fi
+
+        sleep ${RETRY_S}
+    done
+
+    (>&2 echo ">>> Database is not available!")
+    exit 1
+}
+
+# tests to see if an admin user exists.  also happens to test whether or not the database tables have been created.
+function admin_user_exists() {
+    local ADMIN_COUNT=`perform_query "SELECT count(*) as admin_count FROM (SELECT eperson_id FROM epersongroup2eperson WHERE eperson_group_id IN (SELECT uuid FROM epersongroup WHERE name = 'Administrator')) admins, eperson WHERE admins.eperson_id = eperson.uuid" \
+    | sed -n 3p | sed -e 's: ::g'`
+
+    if [ $? == 0 -a ${ADMIN_COUNT:-0} -gt 0 ] ;
+    then
+        return 0
+    fi
+    return 1
+}
+
+# executes the command to create an admin user
+function create_admin_user() {
+    (>&2 echo ">>> Creating DSpace administrative user and DSpace database tables ...")
+    ${DSPACE_INSTALL_DIR}/bin/dspace create-administrator -e ${DSPACE_ADMIN_USERNAME} -f DSpace -l Administrator -p foobar -c EN_US 2>&1 >/dev/null
+}
+
+# updates the runtime configuration of dspace based on docker environment vars
+function perform_runtime_config() {
+    (>&2 echo ">>> Configuring DSpace using the following environment:")
+    (>&2 env)
+    # Edit runtime configuration, configure per environment
+    cd ${DSPACE_INSTALL_DIR}/config
+
+    cp local.cfg.EXAMPLE local.cfg
+
+    sed -e "s:^dspace.hostname = .*:dspace.hostname = ${DSPACE_HOST}:"  -i local.cfg
+    sed -e "s:^dspace.baseUrl = .*:dspace.baseUrl = http\://${DSPACE_HOST}\:${DSPACE_PORT}:"  -i local.cfg
+    sed -e "s:^db.url = .*:db.url = jdbc\:postgresql\://${POSTGRES_DB_PORT}\:${POSTGRES_DB_PORT}/${DSPACE_DB_NAME}:"  -i local.cfg
+    sed -e "s:^db.username = .*:db.username = ${DSPACE_DB_USER}:"  -i local.cfg
+    sed -e "s:^db.password = .*:db.password = ${DSPACE_DB_PASS}:"  -i local.cfg
+    sed -e "s:^loglevel.dspace=.*:loglevel.dspace=DEBUG:" -i log4j.properties
+
+    # enable mediated deposit (could lock it down a bit more by whitelisting users), enable verbose SWORD statements.
+    sed -e "s:^swordv2-server.on-behalf-of.enable = .*:swordv2-server.on-behalf-of.enable = true:" -i modules/swordv2-server.cfg
+    sed -e "s:^swordv2-server.verbose-description.receipt.enable = .*:swordv2-server.verbose-description.receipt.enable = true:" -i modules/swordv2-server.cfg
+}
+
+function import_communities_and_collections() {
+    local COMM_COUNT=`perform_query "SELECT count(*) as community_count FROM community" | sed -n 3p | sed -e 's: ::g'`
+    local COLL_COUNT=`perform_query "SELECT count(*) as collection_count FROM collection" | sed -n 3p | sed -e 's: ::g'`
+
+    if [ ${COMM_COUNT:-0} == 0 -a ${COLL_COUNT:-0} == 0 ] ;
+    then
+        (>&2 echo ">>> Populating Community and Collection hierarchy ...")
+        cd ${DSPACE_INSTALL_DIR}
+        bin/dspace structure-builder -e ${DSPACE_ADMIN_USERNAME} -o /dev/null -f /import.xml
+        if [ $? != 0 ] ;
+        then
+            (>&2 echo ">>> Error creating Communities and Collections!")
+            exit 1
+        fi
+    fi
+
+    return 0
+}
+
+# preserve WORKDIR
+WORKDIR=`pwd`
+
+# Configure DSpace from Docker env vars
+perform_runtime_config
+
+# Insure database is up and create DSpace admin user and database tables if needed
+wait_for_db 2 20
+admin_user_exists
+if [ $? != 0 ] ;
+then
+    create_admin_user
+fi
+
+if [ $? != 0 ] ;
+then
+  (>&2 echo ">>> Error initializing the DSpace database.")
+  exit -1
+fi
+
+# Import communities and collections if they don't already exist
+import_communities_and_collections
+
+# Start jetty
+cd ${WORKDIR}
+
+java -Djetty.http.port=${DSPACE_PORT} -jar /usr/local/jetty/start.jar

--- a/dspace/6.2/wait-and-init-db.sh
+++ b/dspace/6.2/wait-and-init-db.sh
@@ -65,7 +65,7 @@ function perform_runtime_config() {
 
     sed -e "s:^dspace.hostname = .*:dspace.hostname = ${DSPACE_HOST}:"  -i local.cfg
     sed -e "s:^dspace.baseUrl = .*:dspace.baseUrl = http\://${DSPACE_HOST}\:${DSPACE_PORT}:"  -i local.cfg
-    sed -e "s:^db.url = .*:db.url = jdbc\:postgresql\://${POSTGRES_DB_PORT}\:${POSTGRES_DB_PORT}/${DSPACE_DB_NAME}:"  -i local.cfg
+    sed -e "s:^db.url = .*:db.url = jdbc\:postgresql\://${DSPACE_DB_HOST}\:${POSTGRES_DB_PORT}/${DSPACE_DB_NAME}:"  -i local.cfg
     sed -e "s:^db.username = .*:db.username = ${DSPACE_DB_USER}:"  -i local.cfg
     sed -e "s:^db.password = .*:db.password = ${DSPACE_DB_PASS}:"  -i local.cfg
     sed -e "s:^loglevel.dspace=.*:loglevel.dspace=DEBUG:" -i log4j.properties

--- a/postgres/10.3/Dockerfile
+++ b/postgres/10.3/Dockerfile
@@ -1,0 +1,16 @@
+FROM postgres:10.3-alpine
+
+ENV POSTGRES_DB_PORT=${POSTGRES_DB_PORT:-5432} \
+    DSPACE_DB_NAME=${DSPACE_DB_NAME:-dspace} \
+    DSPACE_DB_USER=${DSPACE_DB_USER:-dspace} \
+    DSPACE_DB_PASS=${DSPACE_DB_PASS:-""}
+
+USER root
+
+RUN apk --update --no-cache add postgresql-client postgresql-contrib
+
+ADD init-dspace.sh /docker-entrypoint-initdb.d
+
+RUN chmod 555 /docker-entrypoint-initdb.d/init-dspace.sh
+
+USER postgres

--- a/postgres/10.3/init-dspace.sh
+++ b/postgres/10.3/init-dspace.sh
@@ -1,0 +1,10 @@
+#!/bin/ash
+
+set -v
+
+echo "Initializing 'dspace' database" 2>&1 >/dev/null
+env
+createuser --username=postgres --no-superuser dspace
+createdb --username=postgres --owner=dspace --encoding=UNICODE dspace
+psql --username=postgres dspace -c "CREATE EXTENSION pgcrypto;"
+sed -e "s:^#port = 5432:port = ${POSTGRES_DB_PORT}:" -i /var/lib/postgresql/data/postgresql.conf


### PR DESCRIPTION
Provides DSpace (with the XMLUI, Solr, and SWORDv2 applications) and its dependency, Postgres

- includes README.md updates, docker-compose configuration

To test, perform:
- `docker-compose build dspace`
- `docker-compose build postgres`
- `docker-compose up -d dspace postgres`
- Wait for services to spin up and/or tail logs using `docker logs -f dspace`
- Load http://localhost:8181/xmlui in your browser, login with `dspace-admin@oapass.org`/`foobar`
- You should see one community with one collection
- Load or `curl` http://localhost:8181/swordv2/servicedoc and authenticate with `dspace-admin@oapass.org`/`foobar`.  A SWORD service document should be returned.

After this PR is merged, I'll push the images.