### PR TITLE
Use latest Ember from develop, and model context 1.0

### DIFF
--- a/.env
+++ b/.env
@@ -11,9 +11,9 @@ SUBMISSION_GIT_BRANCH=demo
 # Ember app config
 EMBER_PORT=81
 EMBER_GIT_REPO=https://github.com/OA-PASS/pass-ember
-EMBER_GIT_BRANCH=bf7c71c6
+EMBER_GIT_BRANCH=95c7dd3  
 FEDORA_ADAPTER_BASE=https://pass/fcrepo/rest
-FEDORA_ADAPTER_CONTEXT=https://oa-pass.github.io/pass-data-model/src/main/resources/context.jsonld
+FEDORA_ADAPTER_CONTEXT=https://oa-pass.github.io/pass-data-model/src/main/resources/context-1.0.jsonld
 
 # Fedora config
 FCREPO_PORT=8080
@@ -21,12 +21,12 @@ FCREPO_DEBUG_PORT=5006
 FCREPO_JMS_PORT=61616
 FCREPO_STOMP_PORT=61613
 FCREPO_LOG_LEVEL=INFO
-COMPACTION_URI=https://oa-pass.github.io/pass-data-model/src/main/resources/context.jsonld
+COMPACTION_URI=https://oa-pass.github.io/pass-data-model/src/main/resources/context-1.0.jsonld
 #
 # Pre-loads the PASS context.  Use the same pattern for pre-loading others, see 
 # https://github.com/DataConservancy/fcrepo-jsonld#static-loaded-contexts
-COMPACTION_PRELOAD_URI_PASS_STATIC=https://oa-pass.github.io/pass-data-model/src/main/resources/context.jsonld
-COMPACTION_PRELOAD_FILE_PASS_STATIC=/usr/local/tomcat/lib/context.jsonld
+COMPACTION_PRELOAD_URI_PASS_STATIC=https://oa-pass.github.io/pass-data-model/src/main/resources/context-1.0.jsonld
+COMPACTION_PRELOAD_FILE_PASS_STATIC=/usr/local/tomcat/lib/context-1.0.jsonld
 #
 # Uncomment to have Tomcat dump the headers for each request/response cycle to the console
 #FCREPO_TOMCAT_REQUEST_DUMPER_ENABLED=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   fcrepo:
     build:
       context: ./fcrepo/4.7.5-SNAPSHOT
-    image: oapass/fcrepo:4.7.5-0.0-SNAPSHOT
+    image: oapass/fcrepo:4.7.5-1.0-SNAPSHOT
     container_name: fcrepo
     env_file: .env
     ports: 
@@ -23,7 +23,7 @@ services:
       args:
         EMBER_GIT_REPO: "${EMBER_GIT_REPO}"
         EMBER_GIT_BRANCH: "${EMBER_GIT_BRANCH}"
-    image: oapass/ember:20180412-bf7c71c6
+    image: oapass/ember:20180413-95c7dd3 
     container_name: ember
     env_file: .env
     ports:

--- a/fcrepo/4.7.5-SNAPSHOT/Dockerfile
+++ b/fcrepo/4.7.5-SNAPSHOT/Dockerfile
@@ -50,8 +50,8 @@ RUN apk update && \
     ${CATALINA_HOME}/bin/shutdown.sh && \
     sed -i '/bootstrap/d' conf/tomcat-users.xml
 
-RUN wget -O ${CATALINA_HOME}/lib/context.jsonld \
-   https://oa-pass.github.io/pass-data-model/src/main/resources/context.jsonld
+RUN wget -O ${CATALINA_HOME}/lib/context-1.0.jsonld \
+   https://oa-pass.github.io/pass-data-model/src/main/resources/context-1.0.jsonld
 
 
 COPY WEB-INF/ ${CATALINA_HOME}/webapps/fcrepo/WEB-INF/


### PR DESCRIPTION
# Overview 
* Uses latest ember from `develop`
* Fedora and Ember use model 1.0

# How to test
* Check out this PR locally 
  1.  Check out the latest `master` from pass-docker (e.g. `git checkout master` then `git pull`)
  2.  Create a branch from master to try it out in : `git checkout -b birkland-model-1.0 master`
  3.  Pull the PR into it `git pull https://github.com/birkland/pass-demo-docker.git model-1.0`
  4.  Do `docker-compose pull`
  5. Make sure you edited your `/etc/hosts` file to add an entry for `pass` resolving to `localhost`
     * e.g. add a new line at the end that looks like <pre>127.0.0.1               pass</pre>
  6. Start everything with `docker-compose up -d`
  7. Go to `https://pass` in your browser.  It'll say the site is insecure (due to a self-signed cert).  Proceed anyway
  8.  You'll be directed to the shib login.  (if not, and you see an error, it probably hasn't finished booting. 
 Wait a little while and try again) Use one of the test users (e.g. `aguzun` with the usual test password).  Then you'll be asked to confirm the duration you consent to have your credentials provided.  This is an artifact of our test IDP, the answer doesn't matter.  Just click `accept`
  9.  Now you'll get to the PASS UI.  If you get to a login page, it's fake/unnecessary.  Just enter user `agudzun` as the user, and continue.  There will be a pause as Ember loads the test data
  10. Poke at the Ember app.

Interested Parties: @htpvu 
