### PR TITLE
Fedora PATCH support and validation

### DIFF
--- a/.env
+++ b/.env
@@ -23,14 +23,7 @@ FCREPO_JMS_PORT=61616
 FCREPO_STOMP_PORT=61613
 FCREPO_LOG_LEVEL=INFO
 FCREPO_ACTIVEMQ_CONFIGURATION=classpath:/activemq-queue.xml
-COMPACTION_URI=https://oa-pass.github.io/pass-data-model/src/main/resources/context.jsonld
 
-#
-# Pre-loads the PASS context.  Use the same pattern for pre-loading others, see 
-# https://github.com/DataConservancy/fcrepo-jsonld#static-loaded-contexts
-COMPACTION_PRELOAD_URI_PASS_STATIC=https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.0.jsonld
-COMPACTION_PRELOAD_FILE_PASS_STATIC=/usr/local/tomcat/lib/context-2.0.jsonld
-#
 # Uncomment to have Tomcat dump the headers for each request/response cycle to the console
 #FCREPO_TOMCAT_REQUEST_DUMPER_ENABLED=true
 #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   fcrepo:
     build:
       context: ./fcrepo/4.7.5-SNAPSHOT
-    image: oapass/fcrepo:4.7.5-2.0-SNAPSHOT
+    image: oapass/fcrepo:4.7.5-2.0-SNAPSHOT-1
     container_name: fcrepo
     env_file: .env
     environment:

--- a/fcrepo/4.7.5-SNAPSHOT/Dockerfile
+++ b/fcrepo/4.7.5-SNAPSHOT/Dockerfile
@@ -39,8 +39,8 @@ RUN apk update && \
         | sha1sum -c -  && \
     echo "org.apache.catalina.webresources.Cache.level = SEVERE" \
       >> ${CATALINA_HOME}/conf/logging.properties && \
-    wget -O ${CATALINA_HOME}/lib/jsonld-addon-filters-0.0.4-SNAPSHOT-shaded.jar \
-        https://github.com/DataConservancy/fcrepo-jsonld/releases/download/0.0.4-SNAPSHOT/jsonld-addon-filters-0.0.5-SNAPSHOT-shaded.jar && \
+    wget -O ${CATALINA_HOME}/lib/jsonld-addon-filters-0.0.5-SNAPSHOT-shaded.jar \
+        https://github.com/DataConservancy/fcrepo-jsonld/releases/download/0.0.5-SNAPSHOT/jsonld-addon-filters-0.0.5-SNAPSHOT-shaded.jar && \
     mkdir ${CATALINA_HOME}/webapps/fcrepo && \
     unzip ${CATALINA_HOME}/webapps/fcrepo.war -d ${CATALINA_HOME}/webapps/fcrepo  && \
     rm ${CATALINA_HOME}/webapps/fcrepo.war && \

--- a/fcrepo/4.7.5-SNAPSHOT/Dockerfile
+++ b/fcrepo/4.7.5-SNAPSHOT/Dockerfile
@@ -33,8 +33,8 @@ RUN apk update && \
         | sha1sum -c -  && \
     echo "org.apache.catalina.webresources.Cache.level = SEVERE" \
       >> ${CATALINA_HOME}/conf/logging.properties && \
-    wget -O ${CATALINA_HOME}/lib/jsonld-addon-filters-0.0.2-SNAPSHOT-shaded.jar \
-        https://github.com/DataConservancy/fcrepo-jsonld/releases/download/0.0.2-SNAPSHOT/jsonld-addon-filters-0.0.2-SNAPSHOT-shaded.jar && \
+    wget -O ${CATALINA_HOME}/lib/jsonld-addon-filters-0.0.4-SNAPSHOT-shaded.jar \
+        https://github.com/DataConservancy/fcrepo-jsonld/releases/download/0.0.4-SNAPSHOT/jsonld-addon-filters-0.0.4-SNAPSHOT-shaded.jar && \
     mkdir ${CATALINA_HOME}/webapps/fcrepo && \
     unzip ${CATALINA_HOME}/webapps/fcrepo.war -d ${CATALINA_HOME}/webapps/fcrepo  && \
     rm ${CATALINA_HOME}/webapps/fcrepo.war && \
@@ -53,7 +53,7 @@ RUN apk update && \
     sed -i '/bootstrap/d' conf/tomcat-users.xml
 
 RUN wget -O ${CATALINA_HOME}/lib/context-2.0.jsonld \
-   https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.0.jsonld
+   ${COMPACTION_URI}
 
 
 COPY WEB-INF/ ${CATALINA_HOME}/webapps/fcrepo/WEB-INF/

--- a/fcrepo/4.7.5-SNAPSHOT/Dockerfile
+++ b/fcrepo/4.7.5-SNAPSHOT/Dockerfile
@@ -17,7 +17,9 @@ DEBUG_ARG="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5006" \
 COMPACTION_URI=https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.0.jsonld \
 COMPACTION_PRELOAD_URI_PASS_STATIC=https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.0.jsonld \
 COMPACTION_PRELOAD_FILE_PASS_STATIC=/usr/local/tomcat/lib/context-2.0.jsonld \
-JSONLD_STRICT=true
+JSONLD_STRICT=true \
+JSONLD_CONTEXT_PERSIST=true \
+JSONLD_CONTEXT_MINIMAL=true
 
 EXPOSE ${DEBUG_PORT}
 EXPOSE ${FCREPO_PORT}
@@ -38,7 +40,7 @@ RUN apk update && \
     echo "org.apache.catalina.webresources.Cache.level = SEVERE" \
       >> ${CATALINA_HOME}/conf/logging.properties && \
     wget -O ${CATALINA_HOME}/lib/jsonld-addon-filters-0.0.4-SNAPSHOT-shaded.jar \
-        https://github.com/DataConservancy/fcrepo-jsonld/releases/download/0.0.4-SNAPSHOT/jsonld-addon-filters-0.0.4-SNAPSHOT-shaded.jar && \
+        https://github.com/DataConservancy/fcrepo-jsonld/releases/download/0.0.4-SNAPSHOT/jsonld-addon-filters-0.0.5-SNAPSHOT-shaded.jar && \
     mkdir ${CATALINA_HOME}/webapps/fcrepo && \
     unzip ${CATALINA_HOME}/webapps/fcrepo.war -d ${CATALINA_HOME}/webapps/fcrepo  && \
     rm ${CATALINA_HOME}/webapps/fcrepo.war && \
@@ -47,10 +49,6 @@ RUN apk update && \
 
  RUN export FCREPO_ACTIVEMQ_CONFIGURATION=classpath:/activemq-queue.xml && \
     export FCREPO_JMS_BASEURL=http://${FCREPO_HOST}:${FCREPO_PORT}/fcrepo/rest && \
-    wget -O ${CATALINA_HOME}/lib/slf4j-api-${SLF4J_VERSION}.jar \
-    http://central.maven.org/maven2/org/slf4j/slf4j-api/${SLF4J_VERSION}/slf4j-api-${SLF4J_VERSION}.jar && \
-    wget -O ${CATALINA_HOME}/lib/slf4j-jdk14-${SLF4J_VERSION}.jar \
-    http://central.maven.org/maven2/org/slf4j/slf4j-jdk14/${SLF4J_VERSION}/slf4j-jdk14-${SLF4J_VERSION}.jar && \
     /bin/entrypoint.sh startup.sh && \
     /bin/setup_fedora.sh http://127.0.0.1:${FCREPO_PORT}/${FCREPO_CONTEXT_PATH}/rest && \
     ${CATALINA_HOME}/bin/shutdown.sh && \
@@ -58,7 +56,6 @@ RUN apk update && \
 
 RUN wget -O ${CATALINA_HOME}/lib/context-2.0.jsonld \
    ${COMPACTION_URI}
-
 
 COPY WEB-INF/ ${CATALINA_HOME}/webapps/fcrepo/WEB-INF/
 

--- a/fcrepo/4.7.5-SNAPSHOT/Dockerfile
+++ b/fcrepo/4.7.5-SNAPSHOT/Dockerfile
@@ -13,7 +13,11 @@ FCREPO_SPRING_CONFIGURATION=classpath:/spring/master.xml \
 FCREPO_MODESHAPE_CONFIGURATION=classpath:/pass-repository.json \
 SLF4J_VERSION=1.7.25 \
 DEBUG_PORT=5006 \
-DEBUG_ARG="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5006"
+DEBUG_ARG="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5006" \
+COMPACTION_URI=https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.0.jsonld \
+COMPACTION_PRELOAD_URI_PASS_STATIC=https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.0.jsonld \
+COMPACTION_PRELOAD_FILE_PASS_STATIC=/usr/local/tomcat/lib/context-2.0.jsonld \
+JSONLD_STRICT=true
 
 EXPOSE ${DEBUG_PORT}
 EXPOSE ${FCREPO_PORT}

--- a/fcrepo/4.7.5-SNAPSHOT/conf/web.xml
+++ b/fcrepo/4.7.5-SNAPSHOT/conf/web.xml
@@ -4713,6 +4713,12 @@
       <filter-class>org.dataconservancy.fcrepo.jsonld.request.UriProtocolFilter</filter-class>
       <async-supported>true</async-supported>
     </filter>
+
+    <filter>
+      <filter-name>json-merge-patch-filter</filter-name>
+      <filter-class>org.dataconservancy.fcrepo.jsonld.request.JsonMergePatchFilter</filter-class>
+      <async-supported>true</async-supported>
+    </filter>
     
     <filter-mapping>
       <filter-name>jsonld-compaction-filter</filter-name>
@@ -4726,6 +4732,11 @@
 
     <filter-mapping>
       <filter-name>uri-protocol-filter</filter-name>
+      <url-pattern>/*</url-pattern>
+    </filter-mapping>
+
+    <filter-mapping>
+      <filter-name>json-merge-patch-filter</filter-name>
       <url-pattern>/*</url-pattern>
     </filter-mapping>
 


### PR DESCRIPTION
* Enables [RFC7386](https://tools.ietf.org/html/rfc7386) JSON merge patch support
* Enables "strict mode" that will reject requests that contain jsonld terms not present in the context
* Bakes the default compaction settings for PASS into the image, rather than relying on external configuration (though such config can still be used for overriding)