### PR TITLE
Define DC URI for Fedora

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   fcrepo:
     build:
       context: ./fcrepo/4.7.5-SNAPSHOT
-    image: oapass/fcrepo:4.7.5-2.0-SNAPSHOT-2
+    image: oapass/fcrepo:4.7.5-2.0-SNAPSHOT-3
     container_name: fcrepo
     env_file: .env
     ports:

--- a/fcrepo/4.7.5-SNAPSHOT/lib/pass-node-types.cnd
+++ b/fcrepo/4.7.5-SNAPSHOT/lib/pass-node-types.cnd
@@ -107,4 +107,4 @@
 /*
  * DC types
  */ 
-<dc = 'http://dataconservancy.org/ns/'>
+<dcjsonld = 'http://dataconservancy.org/ns/jsonld#'>

--- a/fcrepo/4.7.5-SNAPSHOT/lib/pass-node-types.cnd
+++ b/fcrepo/4.7.5-SNAPSHOT/lib/pass-node-types.cnd
@@ -102,3 +102,9 @@
 [pass:RepositoryCopy] > fedora:Container mixin
 [pass:Submission] > fedora:Container mixin
 [pass:User] > fedora:Container mixin
+
+
+/*
+ * DC types
+ */ 
+<dc = 'http://dataconservancy.org/ns/'>


### PR DESCRIPTION
Fedora needs namespaces to be predefined. Add the DC URI to the list. 
The tag of the Fedora image is bumped to oapass/fcrepo:4.7.5-2.0-SNAPSHOT-3.
The image has been pushed and can be tested.