### PR TITLE
Update ember

### DIFF
--- a/.env
+++ b/.env
@@ -11,9 +11,12 @@ SUBMISSION_GIT_BRANCH=demo
 # Ember app config
 EMBER_PORT=81
 EMBER_GIT_REPO=https://github.com/OA-PASS/pass-ember
-EMBER_GIT_BRANCH=95c7dd3  
-FEDORA_ADAPTER_BASE=https://pass/fcrepo/rest
-FEDORA_ADAPTER_CONTEXT=https://oa-pass.github.io/pass-data-model/src/main/resources/context-1.0.jsonld
+EMBER_GIT_BRANCH=f5fe924
+
+FEDORA_ADAPTER_BASE=https://pass/fcrepo/rest/
+FEDORA_ADAPTER_CONTEXT=http://example.org/pass/
+FEDORA_ADAPTER_DATA=http://example.org/pass/
+FEDORA_ADAPTER_ES=https://pass/es/
 
 # Fedora config
 FCREPO_HOST=fcrepo
@@ -26,6 +29,10 @@ FCREPO_STOMP_PORT=61613
 FCREPO_LOG_LEVEL=INFO
 FCREPO_LOG_JMS=INFO
 FCREPO_ACTIVEMQ_CONFIGURATION=classpath:/activemq-queue.xml
+
+COMPACTION_URI=http://example.org/pass/
+COMPACTION_PRELOAD_URI_PASS_STATIC=http://example.org/pass/
+COMPACTION_PRELOAD_FILE_PASS_STATIC=/usr/local/tomcat/lib/context-2.0.jsonld
 
 # Uncomment to have Tomcat dump the headers for each request/response cycle to the console
 #FCREPO_TOMCAT_REQUEST_DUMPER_ENABLED=true

--- a/.env
+++ b/.env
@@ -11,7 +11,7 @@ SUBMISSION_GIT_BRANCH=demo
 # Ember app config
 EMBER_PORT=81
 EMBER_GIT_REPO=https://github.com/OA-PASS/pass-ember
-EMBER_GIT_BRANCH=f5fe924
+EMBER_GIT_BRANCH=b901a6f
 
 FEDORA_ADAPTER_BASE=https://pass/fcrepo/rest/
 FEDORA_ADAPTER_CONTEXT=http://example.org/pass/

--- a/.env
+++ b/.env
@@ -11,10 +11,10 @@ SUBMISSION_GIT_BRANCH=demo
 # Ember app config
 EMBER_PORT=81
 EMBER_GIT_REPO=https://github.com/OA-PASS/pass-ember
-EMBER_GIT_BRANCH=b901a6f
+EMBER_GIT_BRANCH=2eaa328
 
 FEDORA_ADAPTER_BASE=https://pass/fcrepo/rest/
-FEDORA_ADAPTER_CONTEXT=http://example.org/pass/
+FEDORA_ADAPTER_CONTEXT=https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.0.jsonld
 FEDORA_ADAPTER_DATA=http://example.org/pass/
 FEDORA_ADAPTER_ES=https://pass/es/
 
@@ -29,10 +29,6 @@ FCREPO_STOMP_PORT=61613
 FCREPO_LOG_LEVEL=INFO
 FCREPO_LOG_JMS=INFO
 FCREPO_ACTIVEMQ_CONFIGURATION=classpath:/activemq-queue.xml
-
-COMPACTION_URI=http://example.org/pass/
-COMPACTION_PRELOAD_URI_PASS_STATIC=http://example.org/pass/
-COMPACTION_PRELOAD_FILE_PASS_STATIC=/usr/local/tomcat/lib/context-2.0.jsonld
 
 # Uncomment to have Tomcat dump the headers for each request/response cycle to the console
 #FCREPO_TOMCAT_REQUEST_DUMPER_ENABLED=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       args:
         EMBER_GIT_REPO: "${EMBER_GIT_REPO}"
         EMBER_GIT_BRANCH: "${EMBER_GIT_BRANCH}"
-    image: oapass/ember:20180511-f5fe924
+    image: oapass/ember:20180514-b901a6f
     container_name: ember
     env_file: .env
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       args:
         EMBER_GIT_REPO: "${EMBER_GIT_REPO}"
         EMBER_GIT_BRANCH: "${EMBER_GIT_BRANCH}"
-    image: oapass/ember:20180413-95c7dd3 
+    image: oapass/ember:20180511-f5fe924
     container_name: ember
     env_file: .env
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       args:
         EMBER_GIT_REPO: "${EMBER_GIT_REPO}"
         EMBER_GIT_BRANCH: "${EMBER_GIT_BRANCH}"
-    image: oapass/ember:20180514-b901a6f
+    image: oapass/ember:20180515-2eaa328
     container_name: ember
     env_file: .env
     ports:


### PR DESCRIPTION
This provides an updated ember image that should integrate with everything else.
A current commit on the pass-ember develop branch was chosen.
I already pushed oapass/ember:20180515-2eaa328 for testing.
Note that there is an updated proxy image. It had not been pushed earlier.
One oddity is that I seemingly add to set the COMPACTION_* variables, but should not need to.

In order to test:

Follow the setup instructions for pass in the README.

```
docker-compose pull ember sp ldap indexer fcrepo proxy idp elasticsearch
docker-compose up ember sp ldap indexer fcrepo proxy idp elasticsearch
```

Wait for the containers to settle down and then visit https://pass. Start developer tools and open the network tab. Login as admin:moo. When you get the the ember login screen look at the network tab and watch Fedora objects be created and modified successfully. Wait a couple minutes to let the indexer catch up. Click the login button in the ember app and play around. Note that Fedora (/fcrepo) and Elasticsearch (/es), requests are working.

Try to create a submission. For the DOI put something in like 10.1021/acsmedchemlett.7b00376. Go through the workflow. At the end you will see submission related objects created successfully even though there will be some errors in the Js console.
