### PR TITLE
Increase ActiveMQ limits to better handle a flood of messages.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   fcrepo:
     build:
       context: ./fcrepo/4.7.5-SNAPSHOT
-    image: oapass/fcrepo:4.7.5-2.0-SNAPSHOT-4
+    image: oapass/fcrepo:4.7.5-2.0-SNAPSHOT-5
     container_name: fcrepo
     env_file: .env
     ports:

--- a/fcrepo/4.7.5-SNAPSHOT/lib/activemq-queue.xml
+++ b/fcrepo/4.7.5-SNAPSHOT/lib/activemq-queue.xml
@@ -38,10 +38,10 @@
 
                     -->
                         <pendingMessageLimitStrategy>
-                            <constantPendingMessageLimitStrategy limit="1000"/>
+                            <constantPendingMessageLimitStrategy limit="2000"/>
                         </pendingMessageLimitStrategy>
                     </policyEntry>
-                    <policyEntry queue=">" producerFlowControl="true" memoryLimit="1mb">
+                    <policyEntry queue=">" producerFlowControl="true" memoryLimit="10mb">
                         <!-- Use VM cursor for better latency
                        For more information, see:
 

--- a/fcrepo/4.7.5-SNAPSHOT/lib/activemq-virtualtopic.xml
+++ b/fcrepo/4.7.5-SNAPSHOT/lib/activemq-virtualtopic.xml
@@ -38,10 +38,10 @@
 
                     -->
                         <pendingMessageLimitStrategy>
-                            <constantPendingMessageLimitStrategy limit="1000"/>
+                            <constantPendingMessageLimitStrategy limit="2000"/>
                         </pendingMessageLimitStrategy>
                     </policyEntry>
-                    <policyEntry queue=">" producerFlowControl="true" memoryLimit="1mb">
+                    <policyEntry queue=">" producerFlowControl="true" memoryLimit="10mb">
                         <!-- Use VM cursor for better latency
                        For more information, see:
 


### PR DESCRIPTION
This is the modification which allowed @jrmartino COEUS load to succeed.
An updated image, oapass/fcrepo:4.7.5-2.0-SNAPSHOT-5, has already been pushed.

In order to test, deposit a bunch of items to Fedora. 
For example, checkout the develop branch of pass-ember, 
modify the docker-compose.yml to use oapass/fcrepo:4.7.5-2.0-SNAPSHOT-5.
Then `docker-compose up`, wait for it to settle, do `ember s`, and check that test data is created and indexed successfully in the debug messages.
