### PR TITLE
Upgrade to fcrepo:4.7.5-2.0-SNAPSHOT-6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   fcrepo:
     build:
       context: ./fcrepo/4.7.5-SNAPSHOT
-    image: oapass/fcrepo:4.7.5-2.0-SNAPSHOT-5
+    image: oapass/fcrepo:4.7.5-2.0-SNAPSHOT-6
     container_name: fcrepo
     env_file: .env
     ports:


### PR DESCRIPTION
Upgrade to fcrepo:4.7.5-2.0-SNAPSHOT-6, which includes support for `Prefer: return=representation` when using methods other than `GET` with JSON-LD.