### PR TITLE
Update fcrepo context, compaction, and authz

### DIFF
--- a/.env
+++ b/.env
@@ -30,6 +30,10 @@ FCREPO_LOG_LEVEL=INFO
 FCREPO_LOG_JMS=INFO
 FCREPO_ACTIVEMQ_CONFIGURATION=classpath:/activemq-queue.xml
 
+PASS_FEDORA_BASEURL=http://fcrepo:8080/fcrepo/rest/
+PASS_ELASTICSEARCH_URL=http://elasticsearch:9200
+
+
 # Uncomment to have Tomcat dump the headers for each request/response cycle to the console
 #FCREPO_TOMCAT_REQUEST_DUMPER_ENABLED=true
 #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   fcrepo:
     build:
       context: ./fcrepo/4.7.5-SNAPSHOT
-    image: oapass/fcrepo:4.7.5-2.0-SNAPSHOT-5
+    image: oapass/fcrepo:4.7.5-2.0-SNAPSHOT-6
     container_name: fcrepo
     env_file: .env
     ports:

--- a/fcrepo/4.7.5-SNAPSHOT/Dockerfile
+++ b/fcrepo/4.7.5-SNAPSHOT/Dockerfile
@@ -20,7 +20,8 @@ COMPACTION_PRELOAD_URI_PASS_STATIC=https://oa-pass.github.io/pass-data-model/src
 COMPACTION_PRELOAD_FILE_PASS_STATIC=/usr/local/tomcat/lib/context-2.0.jsonld \
 JSONLD_STRICT=true \
 JSONLD_CONTEXT_PERSIST=true \
-JSONLD_CONTEXT_MINIMAL=true
+JSONLD_CONTEXT_MINIMAL=true \
+AUTHZ_USE_SHIB_HEADERS=true
 
 EXPOSE ${DEBUG_PORT}
 EXPOSE ${FCREPO_PORT}
@@ -32,7 +33,7 @@ COPY tomcat-bin/* ${CATALINA_HOME}/bin/
 
 RUN apk update && \
     apk add --no-cache ca-certificates wget gettext curl && \
-    export FCREPO_WAR=fcrepo-webapp-${FCREPO_VERSION}.war && \ 
+    export FCREPO_WAR=fcrepo-webapp-${FCREPO_VERSION}.war && \
     wget -O ${CATALINA_HOME}/webapps/fcrepo.war \
     http://central.maven.org/maven2/org/fcrepo/fcrepo-webapp-plus/${FCREPO_VERSION}/fcrepo-webapp-plus-${FCREPO_VERSION}.war && \
     #https://github.com/fcrepo4-exts/fcrepo-webapp-plus/releases/download/fcrepo-webapp-plus-${FCREPO_VERSION}/fcrepo-webapp-plus-webac-${FCREPO_VERSION}.war && \
@@ -42,6 +43,13 @@ RUN apk update && \
       >> ${CATALINA_HOME}/conf/logging.properties && \
     wget -O ${CATALINA_HOME}/lib/jsonld-addon-filters-0.0.5-SNAPSHOT-shaded.jar \
         https://github.com/DataConservancy/fcrepo-jsonld/releases/download/0.0.5-SNAPSHOT/jsonld-addon-filters-0.0.5-SNAPSHOT-shaded.jar && \
+    wget -O ${CATALINA_HOME}/lib/pass-authz-filters-shaded.jar \
+        https://github.com/OA-PASS/pass-authz/releases/download/0.0.1-SNAPSHOT/pass-authz-filters-0.0.1-SNAPSHOT-shaded.jar && \
+    wget -O ${CATALINA_HOME}/webapps/pass-user-service.war \
+        https://github.com/OA-PASS/pass-authz/releases/download/0.0.1-SNAPSHOT/pass-user-service-0.0.1-SNAPSHOT.war && \
+    mkdir ${CATALINA_HOME}/webapps/pass-user-service && \
+    unzip ${CATALINA_HOME}/webapps/pass-user-service.war -d ${CATALINA_HOME}/webapps/pass-user-service  && \
+    rm ${CATALINA_HOME}/webapps/pass-user-service.war && \
     mkdir ${CATALINA_HOME}/webapps/fcrepo && \
     unzip ${CATALINA_HOME}/webapps/fcrepo.war -d ${CATALINA_HOME}/webapps/fcrepo  && \
     rm ${CATALINA_HOME}/webapps/fcrepo.war && \

--- a/fcrepo/4.7.5-SNAPSHOT/Dockerfile
+++ b/fcrepo/4.7.5-SNAPSHOT/Dockerfile
@@ -67,8 +67,10 @@ RUN apk update && \
     ${CATALINA_HOME}/bin/shutdown.sh && \
     sed -i '/bootstrap/d' conf/tomcat-users.xml
 
-RUN wget -O ${CATALINA_HOME}/lib/context-2.0.jsonld \
-   ${COMPACTION_URI}
+RUN wget -O ${COMPACTION_PRELOAD_FILE_PASS_STATIC_2_0} \
+        ${COMPACTION_PRELOAD_URI_PASS_STATIC_2_0} && \
+    wget -O ${COMPACTION_PRELOAD_FILE_PASS_STATIC_2_1} \
+        ${COMPACTION_PRELOAD_URI_PASS_STATIC_2_1}
 
 COPY WEB-INF/ ${CATALINA_HOME}/webapps/fcrepo/WEB-INF/
 

--- a/fcrepo/4.7.5-SNAPSHOT/Dockerfile
+++ b/fcrepo/4.7.5-SNAPSHOT/Dockerfile
@@ -41,8 +41,8 @@ RUN apk update && \
         | sha1sum -c -  && \
     echo "org.apache.catalina.webresources.Cache.level = SEVERE" \
       >> ${CATALINA_HOME}/conf/logging.properties && \
-    wget -O ${CATALINA_HOME}/lib/jsonld-addon-filters-0.0.5-SNAPSHOT-shaded.jar \
-        https://github.com/DataConservancy/fcrepo-jsonld/releases/download/0.0.5-SNAPSHOT/jsonld-addon-filters-0.0.5-SNAPSHOT-shaded.jar && \
+    wget -O ${CATALINA_HOME}/lib/jsonld-addon-filters-0.0.6-SNAPSHOT-shaded.jar \
+        https://github.com/DataConservancy/fcrepo-jsonld/releases/download/0.0.6-SNAPSHOT/jsonld-addon-filters-0.0.6-SNAPSHOT-shaded.jar && \
     wget -O ${CATALINA_HOME}/lib/pass-authz-filters-shaded.jar \
         https://github.com/OA-PASS/pass-authz/releases/download/0.0.1-SNAPSHOT/pass-authz-filters-0.0.1-SNAPSHOT-shaded.jar && \
     wget -O ${CATALINA_HOME}/webapps/pass-user-service.war \

--- a/fcrepo/4.7.5-SNAPSHOT/Dockerfile
+++ b/fcrepo/4.7.5-SNAPSHOT/Dockerfile
@@ -15,9 +15,11 @@ FCREPO_JMS_CONFIGURATION=classpath:/spring/jms.xml \
 SLF4J_VERSION=1.7.25 \
 DEBUG_PORT=5006 \
 DEBUG_ARG="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5006" \
-COMPACTION_URI=https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.0.jsonld \
-COMPACTION_PRELOAD_URI_PASS_STATIC=https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.0.jsonld \
-COMPACTION_PRELOAD_FILE_PASS_STATIC=/usr/local/tomcat/lib/context-2.0.jsonld \
+COMPACTION_URI=https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.1.jsonld \
+COMPACTION_PRELOAD_URI_PASS_STATIC_2_0=https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.0.jsonld \
+COMPACTION_PRELOAD_FILE_PASS_STATIC_2_0=/usr/local/tomcat/lib/context-2.0.jsonld \
+COMPACTION_PRELOAD_URI_PASS_STATIC_2_1=https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.1.jsonld \
+COMPACTION_PRELOAD_FILE_PASS_STATIC_2_1=/usr/local/tomcat/lib/context-2.1.jsonld \
 JSONLD_STRICT=true \
 JSONLD_CONTEXT_PERSIST=true \
 JSONLD_CONTEXT_MINIMAL=true \

--- a/fcrepo/4.7.5-SNAPSHOT/WEB-INF/classes/spring/auth-repo.xml
+++ b/fcrepo/4.7.5-SNAPSHOT/WEB-INF/classes/spring/auth-repo.xml
@@ -20,7 +20,7 @@
 
     <!-- Optional PrincipalProvider that will inspect the request header, "some-header", for user role values -->
     <bean name="headerProvider" class="org.fcrepo.auth.common.HttpHeaderPrincipalProvider">
-      <property name="headerName" value="some-header"/>
+      <property name="headerName" value="pass-roles"/>
       <property name="separator" value=","/>
     </bean>
 

--- a/fcrepo/4.7.5-SNAPSHOT/conf/tomcat-users.xml
+++ b/fcrepo/4.7.5-SNAPSHOT/conf/tomcat-users.xml
@@ -2,6 +2,7 @@
   <!-- Create passwords with ./digest.sh -a sha-256 -h org.apache.catalina.realm.MessageDigestCredentialHandler [PASSWD] -->
   <role rolename="fedoraUser" />
   <role rolename="fedoraAdmin" />
+  <user name="gchoudh2" password="3a4384731fe845887c1307a668942ee37b516826a2c1085828a2e272bb71c544$1$36579ec0da60a5d1bbe0d6cde574400777b225e3e5939a8d5da9349d60020786" roles="fedoraUser" />
   <user name="bootstrap" password="d643a7be407e3f39a924b147a84f48397af41fe465f65b8506daac6cd84904dd$1$0e6a64c63d54a053607b156d48a34fca1ddcaedca71d743b8635f21d50a14fb2" roles="fedoraAdmin" />
   <user name="admin" password="3a4384731fe845887c1307a668942ee37b516826a2c1085828a2e272bb71c544$1$36579ec0da60a5d1bbe0d6cde574400777b225e3e5939a8d5da9349d60020786" roles="fedoraUser" />
   <user name="agudzun" password="c08a7d142bc26f7fadc8667083aa160ba7f3673c0809b9547edb62e1b119088e$1$366a735c8ac0ebbbc98ef20e9657d1339bb6540182eeb355137e5b6975a068c0" roles="fedoraUser" />

--- a/fcrepo/4.7.5-SNAPSHOT/conf/web.xml
+++ b/fcrepo/4.7.5-SNAPSHOT/conf/web.xml
@@ -4719,6 +4719,12 @@
       <filter-class>org.dataconservancy.fcrepo.jsonld.request.JsonMergePatchFilter</filter-class>
       <async-supported>true</async-supported>
     </filter>
+
+    <filter>
+      <filter-name>pass-authz-filter</filter-name>
+      <filter-class>org.dataconservancy.pass.authz.filter.PassRolesFilter</filter-class>
+      <async-supported>true</async-supported>
+    </filter>
     
     <filter-mapping>
       <filter-name>jsonld-compaction-filter</filter-name>
@@ -4737,6 +4743,11 @@
 
     <filter-mapping>
       <filter-name>json-merge-patch-filter</filter-name>
+      <url-pattern>/*</url-pattern>
+    </filter-mapping>
+
+    <filter-mapping>
+      <filter-name>pass-authz-filter</filter-name>
       <url-pattern>/*</url-pattern>
     </filter-mapping>
 

--- a/fcrepo/4.7.5-SNAPSHOT/lib/pass-logback.xml
+++ b/fcrepo/4.7.5-SNAPSHOT/lib/pass-logback.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE configuration>
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%p %date{ISO8601} [%t] \(%c{16}\) %m%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="org.fcrepo.auth" additivity="false" level="${fcrepo.log.auth:-null}">
+    <appender-ref ref="STDOUT"/>
+  </logger>
+  <logger name="org.fcrepo.connector.file" additivity="false" level="${fcrepo.log.connector.file:-null}">
+    <appender-ref ref="STDOUT"/>
+  </logger>
+  <logger name="org.fcrepo.http.api" additivity="false" level="${fcrepo.log.http.api:-null}">
+    <appender-ref ref="STDOUT"/>
+  </logger>
+  <logger name="org.fcrepo.http.commons" additivity="false" level="${fcrepo.log.http.commons:-null}">
+    <appender-ref ref="STDOUT"/>
+  </logger>
+  <logger name="org.fcrepo.jms" additivity="false" level="${fcrepo.log.jms:-null}">
+    <appender-ref ref="STDOUT"/>
+  </logger>
+  <logger name="org.fcrepo.kernel" additivity="false" level="${fcrepo.log.kernel:-null}">
+    <appender-ref ref="STDOUT"/>
+  </logger>
+  <logger name="org.fcrepo.transform" additivity="false" level="${fcrepo.log.transform:-null}">
+    <appender-ref ref="STDOUT"/>
+  </logger>
+  <logger name="org.fcrepo" additivity="false" level="${fcrepo.log:-INFO}">
+    <appender-ref ref="STDOUT"/>
+  </logger>
+
+  <root level="WARN">
+    <appender-ref ref="STDOUT"/>
+  </root>
+</configuration>


### PR DESCRIPTION
* Adds the user service to the `fcrepo` image 
* Updates the jsonld servlet filters so that all responses that are `application/ld+json` are considered for compaction (previously, it only considered `GET`)
* Pre-load `context-2.1.jsonld` for offline use, make it the default.
* Update logging

# Known issues
* Shibboleth has not been updated to release attributes to fcrepo yet; it will do so in #42 .  So the user service is technically present, but cannot be used in the `pass-docker` test environment yet.  Derek is testing it in AWS, where it _will_ work.
