### PR TITLE
Add additional necessary CORS headers

### DIFF
--- a/fcrepo/4.7.5-SNAPSHOT/WEB-INF/web.xml
+++ b/fcrepo/4.7.5-SNAPSHOT/WEB-INF/web.xml
@@ -53,7 +53,7 @@
 
     <init-param>
       <param-name>cors.allowed.headers</param-name>
-      <param-value>Content-Type,X-Requested-With,Accept,Origin,Access-Control-Request-Method,Access-Control-Request-Headers,Authorization,Prefer</param-value>
+      <param-value>Content-Type,X-Requested-With,Accept,Origin,Access-Control-Request-Method,Access-Control-Request-Headers,Authorization,Prefer,Slug,Content-Disposition,Access-Control-Allow-Headers,Access-Control-Allow-Origin,Link</param-value>
     </init-param>
 
     <init-param>


### PR DESCRIPTION
Added whitelisted CORS headers to allow file upload from Ember during development (most notably `Content-Disposition` among others.

This has been tested and confirmed working.
