### PR TITLE
Remove hard-coded Repository resources that were causing test data to fail.

### DIFF
--- a/fcrepo/4.7.5-SNAPSHOT/bin/setup_fedora.sh
+++ b/fcrepo/4.7.5-SNAPSHOT/bin/setup_fedora.sh
@@ -94,5 +94,3 @@ create_object "users"
 curl -v -i -# -u bootstrap:bootstrap -X PUT -H "Content-Type: text/turtle" --data-binary "@conf/acl.ttl" ${REPO}/.acl
 curl -v -i -# -u bootstrap:bootstrap -X PUT -H "Content-Type: text/turtle" --data-binary "@conf/authz.ttl" ${REPO}/.acl/authz
 curl -v -i -# -u bootstrap:bootstrap -X PATCH -H "Content-Type: application/sparql-update" -d "INSERT { <> <http://www.w3.org/ns/auth/acl#accessControl> </fcrepo/rest/.acl> } WHERE {}" ${REPO}/
-curl -v -i -# -u bootstrap:bootstrap -X PUT -H "Content-Type: text/turtle" --data-binary "@conf/nih.ttl" ${REPO}/repositories/nih
-curl -v -i -# -u bootstrap:bootstrap -X PUT -H "Content-Type: text/turtle" --data-binary "@conf/js.ttl" ${REPO}/repositories/js


### PR DESCRIPTION
To test:
1. check out this PR
2. rebuild the fcrepo container (`docker-compose build --no-cache fcrepo`)
3. spin up the docker containers `docker-compose up`
4. wait for everything to come up
5. Load and login to `https://pass`
6. Wait for test data to load (having the chrome devtools up while loading pass helps)

No errors should be seen, and eventually the login page (or PASS home page, depending on your ember revision) should show.