### PR TITLE
Set AJP packetSize parameter for the Fedora Tomcat.

### DIFF
--- a/fcrepo/4.7.5-SNAPSHOT/conf/server.xml
+++ b/fcrepo/4.7.5-SNAPSHOT/conf/server.xml
@@ -113,7 +113,7 @@
     -->
 
     <!-- Define an AJP 1.3 Connector on port 8009 -->
-    <Connector port="8009" protocol="AJP/1.3" redirectPort="8443" tomcatAuthentication="false" tomcatAuthorization="true"/>
+    <Connector port="8009" protocol="AJP/1.3" redirectPort="8443" tomcatAuthentication="false" tomcatAuthorization="true" packetSize="65536"/>
 
 
     <!-- An Engine represents the entry point (within Catalina) that processes


### PR DESCRIPTION
Set AJP packetSize parameter for the Fedora Tomcat to the same size as ProxyIOBufferSize in the SP Apache HTTPd proxy.  (see also: https://httpd.apache.org/docs/2.4/mod/mod_proxy.html#proxyiobuffersize)

To test:
1. re-build the fcrepo container (`docker-compose build --no-cache fcrepo`)
2. Start docker containers (`docker-compose up -d`)
3. After everything comes up, log in to `https://pass`
4. wait for test data to load
4. Grab the shib cookie and attempt to `POST` a file to the files container at `https://pass/fcrepo/files`

Something like:
`curl --verbose -u admin:moo -H "Content-Type: application/xml" -X POST -d @./foo.xml -k --cookie file-with-shib-cookie.txt https://pass/fcrepo/rest/files`

POST should succeed with a `201`, where before it was failing with a `500`.