### PR TITLE
Update 'pass-ember' to include user service integration stuffs

### DIFF
--- a/.env
+++ b/.env
@@ -11,7 +11,8 @@ SUBMISSION_GIT_BRANCH=demo
 # Ember app config
 EMBER_PORT=81
 EMBER_GIT_REPO=https://github.com/OA-PASS/pass-ember
-EMBER_GIT_BRANCH=b736354
+EMBER_GIT_BRANCH=902695a
+USER_SERVICE_URL=https://pass/pass-user-service/whoami
 
 FEDORA_ADAPTER_BASE=https://pass/fcrepo/rest/
 FEDORA_ADAPTER_CONTEXT=https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.2.jsonld

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       args:
         EMBER_GIT_REPO: "${EMBER_GIT_REPO}"
         EMBER_GIT_BRANCH: "${EMBER_GIT_BRANCH}"
-    image: oapass/ember:20180523-b736354
+    image: oapass/ember:20180606-902695a
     container_name: ember
     env_file: .env
     ports:


### PR DESCRIPTION
* Bump the version of ember to a good version that has the user service integration
* All references to `Store.findAll` have been removed
  * On initial app load, a search request is still made, similar to the prior mechanism used to populate dummy test data. This should not effect functionality as nothing is done with the response when real data is present

## Testing
The main point of this PR is the integration of the user service in the `pass-docker` environment.
* Logging in through Shib should work as expected
  * The users `staff1, faculty1, faculty2` should be able to login through Shib and be able to use the Ember app
  * `staff1` and `faculty1` should be able to see their grants in the Grants page
  * `faculty2` should see nothing in the Grants page, as this user has no associated grants
* With the above users, the rest of the site functionality should be have as expected
  * The proper grants should appear in the Grants page
  * When starting the environment fresh, no submissions will be present 
  * Above users should be able to move through the submission workflow as expected when submitting using a DOI (example: `10.1103/PhysRevFluids.1.073604`) **The grant picker widget in the submission workflow is still in flux. Prefer starting a submission from the Grants page to pre-attach a grant**

## Known Issues
* Submission workflow
  * Autocomplete is not yet available for journal names and there is unfortunately no fallback behavior. This information will be populated from a valid DOI, however.