### PR TITLE
Add more test users with grant data

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ There are four users that can log in via Shibboleth. These can be used to log in
 * `staff2` A staff member who does not have grants. Because PASS policy is to only allow faculty in, this user will be denied access to the user service, or the repository.
 * `faculty1` A faculty member who does have lots of grants, and therefore does have a User resource already, and is a PI on grants.
 * `faculty2` A faculty member who does not have grants. Because PASS policy is to give faculty submitter privileges, the first time this person logs to shibboleth and hits the user service, a new User resource is created, but the user should not be allowed to associate grants with his or her submissions.
+* `nih-user` Person with NIH grants
+* `ed-user` Person with DOE gtants
+* `usaid-user` Person with USAID grants
 
 
 <h2><a id="stop" href="#stop">Stopping</a></h2>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   fcrepo:
     build:
       context: ./fcrepo/4.7.5-SNAPSHOT
-    image: oapass/fcrepo:4.7.5-2.2-SNAPSHOT-2
+    image: oapass/fcrepo:4.7.5-2.2-SNAPSHOT-3
     container_name: fcrepo
     env_file: .env
     ports:
@@ -79,7 +79,7 @@ services:
 
   ldap:
     build: ./ldap/
-    image: oapass/ldap:20180518
+    image: oapass/ldap:20180608
     container_name: ldap
     networks:
      - back

--- a/fcrepo/4.7.5-SNAPSHOT/conf/tomcat-users.xml
+++ b/fcrepo/4.7.5-SNAPSHOT/conf/tomcat-users.xml
@@ -8,5 +8,8 @@
   <user name="staff2" password="c08a7d142bc26f7fadc8667083aa160ba7f3673c0809b9547edb62e1b119088e$1$366a735c8ac0ebbbc98ef20e9657d1339bb6540182eeb355137e5b6975a068c0" roles="fedoraUser" />
   <user name="faculty1" password="c1894208115e79c594e7f133140e637fc4d8c8e8d43cff969f92261d8488988f$1$27bee1d70a6bd6d40d7862d23cfeb5836dc0edc47f78da0da42d6a781b471395" roles="fedoraUser" />
   <user name="faculty2" password="27387daea77f878f82b46c7e323db3245ce2fa079ab2c6f6c410bcbac4cb7da5$1$84f7dcbeb8fff3fa1bbcd50b41f272eec890f21749ce774a03742fa2d3a7399b" roles="fedoraUser" />
+  <user name="nih-user" password="27387daea77f878f82b46c7e323db3245ce2fa079ab2c6f6c410bcbac4cb7da5$1$84f7dcbeb8fff3fa1bbcd50b41f272eec890f21749ce774a03742fa2d3a7399b" roles="fedoraUser" />
+  <user name="ed-user" password="27387daea77f878f82b46c7e323db3245ce2fa079ab2c6f6c410bcbac4cb7da5$1$84f7dcbeb8fff3fa1bbcd50b41f272eec890f21749ce774a03742fa2d3a7399b" roles="fedoraUser" />
+  <user name="usaid-user" password="27387daea77f878f82b46c7e323db3245ce2fa079ab2c6f6c410bcbac4cb7da5$1$84f7dcbeb8fff3fa1bbcd50b41f272eec890f21749ce774a03742fa2d3a7399b" roles="fedoraUser" />
   <user name="fedoraAdmin" password="53253a46e9f2f74e6a1141f654eb0cb4a71624d0493e7289489ada0c6255a1f0$1$4ab46c609603537a8665e0dde3a6aaadae24914cb4d8cff10084bb1a7a45c91e" roles="fedoraAdmin" />
 </tomcat-users>

--- a/ldap/users.ldif
+++ b/ldap/users.ldif
@@ -60,3 +60,47 @@ userPassword: moo
 employeeNumber: 2040608
 displayName: Faculty Hasnogrants
 employeeType: FACULTY
+
+dn: uid=nih-user,ou=People,dc=pass
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+objectClass: inetOrgPerson
+givenName: Nihu
+sn: Ser
+cn: Nihu Ser
+mail: nihuser@jhu.edu
+userPassword: moo
+employeeNumber: 00001421
+displayName: Nihu Ser
+employeeType: FACULTY
+
+dn: uid=ed-user,ou=People,dc=pass
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+objectClass: inetOrgPerson
+givenName: Ed
+sn: User
+cn: Ed User
+mail: eduser@jhu.edu
+userPassword: moo
+employeeNumber: 00010090
+displayName: Ed User
+employeeType: FACULTY
+
+dn: uid=usaid-user,ou=People,dc=pass
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+objectClass: inetOrgPerson
+givenName: Usai
+sn: Duser
+cn: Usai Duser
+mail: usaiduser@jhu.edu
+userPassword: moo
+employeeNumber: 00003088
+displayName: Usai Duser
+employeeType: FACULTY
+
+


### PR DESCRIPTION
This PR includes changes introduced in PR(https://github.com/OA-PASS/pass-docker/pull/61), update so new images should include all changes from `master`

## Testing
First and foremost, all recent changes in `master` must still work:
* Deposit services must work!

This PR adds three new test users with grants attached. New usernames to be used to login to PASS:
* `nih-user`
* `ed-user`
* `usaid-user`