### PR TITLE
Use hashes for stable testing and building

### DIFF
--- a/.env
+++ b/.env
@@ -5,7 +5,7 @@ FTP_PORT=21
 # Ember app config
 EMBER_PORT=81
 EMBER_GIT_REPO=https://github.com/OA-PASS/pass-ember
-EMBER_GIT_BRANCH=902695a
+EMBER_GIT_BRANCH=7f9c04d
 USER_SERVICE_URL=https://pass/pass-user-service/whoami
 
 FEDORA_ADAPTER_BASE=https://pass/fcrepo/rest/

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ There are four users that can log in via Shibboleth. These can be used to log in
 * `nih-user` Person with NIH grants
 * `ed-user` Person with DOE gtants
 * `usaid-user` Person with USAID grants
+* `incomplete-nih-user` Person with incomplete submissions harvested from NIHMS
 
 
 <h2><a id="stop" href="#stop">Stopping</a></h2>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   fcrepo:
     build:
       context: ./fcrepo/4.7.5-SNAPSHOT
-    image: oapass/fcrepo:4.7.5-2.2-SNAPSHOT-3
+    image: oapass/fcrepo:4.7.5-2.2-SNAPSHOT-4@sha256:5af64e29c4e0ecc0887c94ab5ea2fe6eea959e0dd30995985d4226b65de951a9
     container_name: fcrepo
     env_file: .env
     ports:
@@ -27,7 +27,7 @@ services:
       args:
         EMBER_GIT_REPO: "${EMBER_GIT_REPO}"
         EMBER_GIT_BRANCH: "${EMBER_GIT_BRANCH}"
-    image: oapass/ember:20180606-902695a
+    image: oapass/ember:20180609-7f9c04d@sha256:8b284b601a1554ba3e110fffbd3ef613081a7ef05aab40fcc425cb5f75a31da6
     container_name: ember
     env_file: .env
     ports:
@@ -37,7 +37,7 @@ services:
 
   ftpserver:
     build: ./ftpserver/0.0.1-demo
-    image: oapass/ftpserver
+    image: oapass/ftpserver@sha256:145f7e3bb494deeb1e1c587f34f0f54649f22d6ef0c107bacd022b0308146ddb
     container_name: ftpserver
     env_file: .env
     ports:
@@ -47,7 +47,7 @@ services:
 
   proxy:
     build: ./httpd-proxy/
-    image: oapass/httpd-proxy:20180608
+    image: oapass/httpd-proxy:20180608@sha256:3b6f6623d0e87e4b2e11d2dcfbd9a2321b5f05d036073f142a4ee3deaad29782
     container_name: proxy
     networks:
      - front
@@ -58,7 +58,7 @@ services:
 
   idp:
     build: ./idp/3.3.2
-    image: oapass/idp:20180518
+    image: oapass/idp:20180518@sha256:8fc230e81574161626c8cebd9fda35ae2ff0f8a0c8bce085397972ecb09ce7eb
     container_name: idp
     depends_on:
      - ldap
@@ -79,14 +79,14 @@ services:
 
   ldap:
     build: ./ldap/
-    image: oapass/ldap:20180608
+    image: oapass/ldap:20180609@sha256:a90044c91d70735f8a0b10cf63151d109fbb87fd775d48f5bc02a91c04fbd882
     container_name: ldap
     networks:
      - back
 
   sp:
     build: ./sp/2.6.1
-    image: oapass/sp:20180518
+    image: oapass/sp:20180518@sha256:ab2d1c3caec871b1154bd528052e3ecc8d9e09c6eed72af5af2b3f808c66be70
     container_name: sp
     networks:
      - back
@@ -95,7 +95,7 @@ services:
 
   dspace:
     build: ./dspace/6.2
-    image: oapass/dspace
+    image: oapass/dspace@sha256:8b1482a4b8ac31fc656ada66184a7a48e0a0e5dfbcf9aacbe308956f25828abf
     container_name: dspace
     env_file: .env
     ports:
@@ -107,7 +107,7 @@ services:
 
   postgres:
     build: ./postgres/10.3
-    image: oapass/postgres
+    image: oapass/postgres@sha256:a16b49990b5ee111efdbce63eefa4a56ae1257d16114ecaeb584117074deefaa
     container_name: postgres
     env_file: .env
     ports:
@@ -117,14 +117,14 @@ services:
 
   indexer:
     build: ./indexer/0.0.10-SNAPSHOT
-    image: oapass/indexer:0.0.10-2.2-SNAPSHOT
+    image: oapass/indexer:0.0.10-2.2-SNAPSHOT-1@sha256:5cbba3d4f195ba28fd4b0111baf8a95a11bccdde44091538c31090c4df70b849
     container_name: indexer
     env_file: .env
     networks:
       - back
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.3
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.3@sha256:ccfad77c0731c010e6ff8c43b4ab50f5ce90c0fa4e65846530779c5c6707c20a
     container_name: elasticsearch
     env_file: .env
     environment:
@@ -146,7 +146,7 @@ services:
       - assets
 
   assets:
-    image: birkland/assets:2018-06-05
+    image: birkland/assets:2018-06-09@sha256:f0b81bd3230c3774bd8330107bae2e3de1b09f8664b97003b276d827cff01297
     build: ./assets
     volumes:
       - passdata:/data
@@ -160,7 +160,7 @@ services:
 
   deposit:
     build: ./deposit-services/0.0.3-2.2
-    image: oapass/deposit-services:0.0.3-2.2
+    image: oapass/deposit-services:0.0.3-2.2@sha256:42c092b9a84112ca6feb96e5e30307a6d45142117a6bda8bddd170b1702f1a2b
     container_name: deposit
     env_file: .env
     ports:

--- a/fcrepo/4.7.5-SNAPSHOT/Dockerfile
+++ b/fcrepo/4.7.5-SNAPSHOT/Dockerfile
@@ -1,6 +1,9 @@
-FROM tomcat:8.5.24-jre8-alpine
+FROM tomcat:8.5.31-jre8-alpine@sha256:f9a53932a3cc61ea3a1c307e7bf60897bce356c60c61beb0a1d1cdc5c13c9b83
 
 ENV FCREPO_VERSION=4.7.5 \
+JSONLD_ADDON_VERSION=0.0.6-SNAPSHOT \
+PASS_AUTHZ_VERSION=0.0.3-SNAPSHOT \
+JMS_ADDON_VERSION=0.0.2 \
 FCREPO_HOME=${CATALINA_HOME}/fcrepo4-data \
 FCREPO_HOST=fcrepo \
 FCREPO_PORT=8080 \
@@ -50,20 +53,28 @@ RUN apk update && \
         | sha1sum -c -  && \
     echo "org.apache.catalina.webresources.Cache.level = SEVERE" \
       >> ${CATALINA_HOME}/conf/logging.properties && \
-    wget -O ${CATALINA_HOME}/lib/jsonld-addon-filters-0.0.6-SNAPSHOT-shaded.jar \
-        https://github.com/DataConservancy/fcrepo-jsonld/releases/download/0.0.6-SNAPSHOT/jsonld-addon-filters-0.0.6-SNAPSHOT-shaded.jar && \
+    wget -O ${CATALINA_HOME}/lib/jsonld-addon-filters-${JSONLD_ADDON_VERSION}-shaded.jar \
+        https://github.com/DataConservancy/fcrepo-jsonld/releases/download/${JSONLD_ADDON_VERSION}/jsonld-addon-filters-${JSONLD_ADDON_VERSION}-shaded.jar && \
+    echo "fa95adf77b0933f163e213f8133e8d78df7a9141 *${CATALINA_HOME}/lib/jsonld-addon-filters-${JSONLD_ADDON_VERSION}-shaded.jar" \
+        | sha1sum -c -  && \
     wget -O ${CATALINA_HOME}/lib/pass-authz-filters-shaded.jar \
-        https://github.com/OA-PASS/pass-authz/releases/download/0.0.3-SNAPSHOT/pass-authz-filters-0.0.3-SNAPSHOT-shaded.jar && \
+        https://github.com/OA-PASS/pass-authz/releases/download/${PASS_AUTHZ_VERSION}/pass-authz-filters-${PASS_AUTHZ_VERSION}-shaded.jar && \
+    echo "dfaa302043005f8c6201459d79997e9d3009daf1 *${CATALINA_HOME}/lib/pass-authz-filters-shaded.jar" \
+        | sha1sum -c -  && \
     wget -O ${CATALINA_HOME}/webapps/pass-user-service.war \
-        https://github.com/OA-PASS/pass-authz/releases/download/0.0.3-SNAPSHOT/pass-user-service-0.0.3-SNAPSHOT.war && \
+        https://github.com/OA-PASS/pass-authz/releases/download/${PASS_AUTHZ_VERSION}/pass-user-service-${PASS_AUTHZ_VERSION}.war && \
+    echo "145c64206c3d63a9f9ca9eb82f9006522239643d *${CATALINA_HOME}/webapps/pass-user-service.war" \
+        | sha1sum -c -  && \
     mkdir ${CATALINA_HOME}/webapps/pass-user-service && \
     unzip ${CATALINA_HOME}/webapps/pass-user-service.war -d ${CATALINA_HOME}/webapps/pass-user-service  && \
     rm ${CATALINA_HOME}/webapps/pass-user-service.war && \
     mkdir ${CATALINA_HOME}/webapps/fcrepo && \
     unzip ${CATALINA_HOME}/webapps/fcrepo.war -d ${CATALINA_HOME}/webapps/fcrepo  && \
     rm ${CATALINA_HOME}/webapps/fcrepo.war && \
-    wget -O ${CATALINA_HOME}/webapps/fcrepo/WEB-INF/lib/jms-addon-0.0.2.jar \
-            https://github.com/DataConservancy/fcrepo-jms/releases/download/jms-addon-0.0.2/jms-addon-0.0.2.jar && \
+    wget -O ${CATALINA_HOME}/webapps/fcrepo/WEB-INF/lib/jms-addon-${JMS_ADDON_VERSION}.jar \
+            https://github.com/DataConservancy/fcrepo-jms/releases/download/jms-addon-${JMS_ADDON_VERSION}/jms-addon-${JMS_ADDON_VERSION}.jar && \
+    echo "5f3cbb87fc9117b5761efa38c0a085b017166729 *${CATALINA_HOME}/webapps/fcrepo/WEB-INF/lib/jms-addon-${JMS_ADDON_VERSION}.jar" \
+        | sha1sum -c -  && \
     chmod 700 /bin/entrypoint.sh && \
     chmod 700 /bin/setup_fedora.sh
 

--- a/fcrepo/4.7.5-SNAPSHOT/conf/tomcat-users.xml
+++ b/fcrepo/4.7.5-SNAPSHOT/conf/tomcat-users.xml
@@ -11,5 +11,6 @@
   <user name="nih-user" password="27387daea77f878f82b46c7e323db3245ce2fa079ab2c6f6c410bcbac4cb7da5$1$84f7dcbeb8fff3fa1bbcd50b41f272eec890f21749ce774a03742fa2d3a7399b" roles="fedoraUser" />
   <user name="ed-user" password="27387daea77f878f82b46c7e323db3245ce2fa079ab2c6f6c410bcbac4cb7da5$1$84f7dcbeb8fff3fa1bbcd50b41f272eec890f21749ce774a03742fa2d3a7399b" roles="fedoraUser" />
   <user name="usaid-user" password="27387daea77f878f82b46c7e323db3245ce2fa079ab2c6f6c410bcbac4cb7da5$1$84f7dcbeb8fff3fa1bbcd50b41f272eec890f21749ce774a03742fa2d3a7399b" roles="fedoraUser" />
+  <user name="incomplete-nih-user" password="27387daea77f878f82b46c7e323db3245ce2fa079ab2c6f6c410bcbac4cb7da5$1$84f7dcbeb8fff3fa1bbcd50b41f272eec890f21749ce774a03742fa2d3a7399b" roles="fedoraUser" />
   <user name="fedoraAdmin" password="53253a46e9f2f74e6a1141f654eb0cb4a71624d0493e7289489ada0c6255a1f0$1$4ab46c609603537a8665e0dde3a6aaadae24914cb4d8cff10084bb1a7a45c91e" roles="fedoraAdmin" />
 </tomcat-users>

--- a/indexer/0.0.10-SNAPSHOT/Dockerfile
+++ b/indexer/0.0.10-SNAPSHOT/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre-alpine
+FROM openjdk:8u151-jre-alpine3.7@sha256:795d1c079217bdcbff740874b78ddea80d5df858b3999951a33871ee61de15ce
 
 ENV PI_VERSION=0.0.10
 
@@ -8,6 +8,8 @@ ADD wait_and_start.sh /app
 
 RUN apk add --no-cache ca-certificates wget gettext curl && \
     wget https://github.com/OA-PASS/pass-indexer/releases/download/${PI_VERSION}/pass-indexer-cli-${PI_VERSION}-SNAPSHOT-shaded.jar && \
+    echo "2d86da5eb28d6161b543041e13c62298d7aa017b *pass-indexer-cli-${PI_VERSION}-SNAPSHOT-shaded.jar" \
+        | sha1sum -c -  && \
     rm -rf /var/cache/apk/ && \
     chmod 700 wait_and_start.sh 
 

--- a/ldap/users.ldif
+++ b/ldap/users.ldif
@@ -89,6 +89,20 @@ employeeNumber: 00010090
 displayName: Ed User
 employeeType: FACULTY
 
+dn: uid=incomplete-nih-user,ou=People,dc=pass
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+objectClass: inetOrgPerson
+givenName: Incomplete
+sn: Nihuser
+cn: Incomplete Nihuser
+mail: incompletenihuser@jhu.edu
+userPassword: moo
+employeeNumber: 00023666
+displayName: Incomplete Nihuser
+employeeType: FACULTY
+
 dn: uid=usaid-user,ou=People,dc=pass
 objectClass: organizationalPerson
 objectClass: person


### PR DESCRIPTION
# Overview
* Uses image hashes in `docker-compose.yml` for referencing specific images unambiguously
* Uses hashes in `Dockerfile` for verifying base image and dependencies for `fcrepo` and `indexer` images
* Adds a new test user `incomplete-nih-user` who has incomplete submissions detected by the nihms etl
* Uses latest `assets` data updates, with updated jscholarship and NIH metadata, fixed USAID funder-to-policy link

# To test
* Check out this PR
* do a `docker-compose pull` to bring in all images
* Make sure any existing runs are destroyed, docker volumes are clean `docker-compose down -v; docker volume prune`
* Start everything `docker-compose up`, and take a look