### PR TITLE
Fox 404 error when loading ember URLs directly

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
 
   proxy:
     build: ./httpd-proxy/
-    image: oapass/httpd-proxy:20180608@sha256:3b6f6623d0e87e4b2e11d2dcfbd9a2321b5f05d036073f142a4ee3deaad29782
+    image: oapass/httpd-proxy:20180609@sha256:d73e25407c5eb20fa2271734cdb0d24db2b4efde941d8706e116bec1198c5d95
     container_name: proxy
     networks:
      - front
@@ -86,7 +86,7 @@ services:
 
   sp:
     build: ./sp/2.6.1
-    image: oapass/sp:20180518@sha256:ab2d1c3caec871b1154bd528052e3ecc8d9e09c6eed72af5af2b3f808c66be70
+    image: oapass/sp:20180609@sha256:7f2066338cf300d88eb8545b35261f64e1749086a7bed28536f0417f2582056e
     container_name: sp
     networks:
      - back

--- a/httpd-proxy/etc-httpd/conf.d/httpd.conf
+++ b/httpd-proxy/etc-httpd/conf.d/httpd.conf
@@ -4,10 +4,15 @@ RewriteEngine on
 ReWriteCond %{SERVER_PORT} !^443$
 RewriteRule ^/(.*) https://%{HTTP_HOST}/$1 [NC,R,L]
 
+ErrorLog /dev/stdout
+ErrorLogFormat "httpd-error [%{u}t] [%-m:%l] [pid %P:tid %T] %7F: %E: [client\ %a] %M% ,\ referer\ %{Referer}i"
+LogLevel warn
+
 ServerName pass
 
 <VirtualHost *:443>
     DocumentRoot "/var/www/html"
+    AllowEncodedSlashes NoDecode
 
     SSLEngine on
 
@@ -93,3 +98,32 @@ EECDH EDH+aRSA !aNULL !eNULL !LOW !3DES !MD5 !EXP !PSK !SRP !DSS !RC4"
     ProxyPass / http://sp/
 
 </VirtualHost>
+
+<IfModule log_config_module>
+    #
+    # The following directives define some format nicknames for use with
+    # a CustomLog directive (see below).
+    #
+    LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+    LogFormat "%h %l %u %t \"%r\" %>s %b" common
+
+    <IfModule logio_module>
+      # You need to enable mod_logio.c to use %I and %O
+      LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %I %O" combinedio
+    </IfModule>
+
+    #
+    # The location and format of the access logfile (Common Logfile Format).
+    # If you do not define any access logfiles within a <VirtualHost>
+    # container, they will be logged here.  Contrariwise, if you *do*
+    # define per-<VirtualHost> access logfiles, transactions will be
+    # logged therein and *not* in this file.
+    #
+    #CustomLog "logs/access_log" common
+
+    #
+    # If you prefer a logfile with access, agent, and referer information
+    # (Combined Logfile Format) you can use the following directive.
+    #
+    CustomLog /dev/stdout "httpd-combined %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\""
+</IfModule>

--- a/sp/2.6.1/etc-httpd/conf.d/sp.conf
+++ b/sp/2.6.1/etc-httpd/conf.d/sp.conf
@@ -1,5 +1,6 @@
 ServerName pass
 LoadModule proxy_ajp_module modules/mod_proxy_ajp.so
+AllowEncodedSlashes NoDecode
 
 <VirtualHost *:80>
 


### PR DESCRIPTION
Apache was configured by default to automatically return 404 when
URLs contain an encoded slash.  Fixed it so that encoded slashes are
ignored

Also added access logs to the proxy container.