### PR TITLE
Use static images for Ember

### DIFF
--- a/.env
+++ b/.env
@@ -6,12 +6,6 @@ FTP_PORT=21
 EMBER_PORT=81
 EMBER_GIT_REPO=https://github.com/OA-PASS/pass-ember
 EMBER_GIT_BRANCH=2e1011a
-USER_SERVICE_URL=https://pass/pass-user-service/whoami
-
-FEDORA_ADAPTER_BASE=//fcrepo/rest/
-FEDORA_ADAPTER_CONTEXT=https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.2.jsonld
-FEDORA_ADAPTER_DATA=http://oapass.org/ns/pass#
-FEDORA_ADAPTER_ES=//es/
 
 # Fedora config
 FCREPO_HOST=fcrepo

--- a/.env
+++ b/.env
@@ -8,10 +8,10 @@ EMBER_GIT_REPO=https://github.com/OA-PASS/pass-ember
 EMBER_GIT_BRANCH=2e1011a
 USER_SERVICE_URL=https://pass/pass-user-service/whoami
 
-FEDORA_ADAPTER_BASE=https://pass/fcrepo/rest/
+FEDORA_ADAPTER_BASE=//fcrepo/rest/
 FEDORA_ADAPTER_CONTEXT=https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.2.jsonld
 FEDORA_ADAPTER_DATA=http://oapass.org/ns/pass#
-FEDORA_ADAPTER_ES=https://pass/es/
+FEDORA_ADAPTER_ES=//es/
 
 # Fedora config
 FCREPO_HOST=fcrepo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       args:
         EMBER_GIT_REPO: "${EMBER_GIT_REPO}"
         EMBER_GIT_BRANCH: "${EMBER_GIT_BRANCH}"
-    image: oapass/ember:20180612-2e1011a@sha256:72b308894faf1af0e711a4e92fe5ad1a73eb66ff239f0abaa582233131c99294
+    image: oapass/ember:20180612-2e1011a@sha256:5475f07e0212b362110e96d5cc1f9827f5f9820a9e2f4c99b3b9ec889ee3e80d
     container_name: ember
     env_file: .env
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,8 +30,6 @@ services:
     image: oapass/ember:20180612-2e1011a@sha256:72b308894faf1af0e711a4e92fe5ad1a73eb66ff239f0abaa582233131c99294
     container_name: ember
     env_file: .env
-    ports:
-      - "${EMBER_PORT}:${EMBER_PORT}"
     networks:
       - back
 

--- a/ember/Dockerfile
+++ b/ember/Dockerfile
@@ -1,13 +1,15 @@
-FROM alpine:3.7
+FROM alpine:3.7 as ember-builder
 
 ARG EMBER_GIT_REPO
 ARG EMBER_GIT_BRANCH
 
 ENV EMBER_GIT_BRANCH=${EMBER_GIT_BRANCH:-master} \
     EMBER_GIT_REPO=${EMBER_GIT_REPO:-https://github.com/OA-PASS/pass-ember} \
-    EMBER_BUILD_DIR=/ember
-
-COPY bin/entrypoint.sh /bin
+    EMBER_BUILD_DIR=/ember \
+    FEDORA_ADAPTER_BASE=${FEDORA_ADAPTER_BASE:-//fcrepo/rest/} \
+    FEDORA_ADAPTER_CONTEXT=${FEDORA_ADAPTER_CONTEXT:-https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.1.jsonld} \
+    FEDORA_ADAPTER_DATA=${FEDORA_ADAPTER_DATA:-http://example.org/pass/} \
+    FEDORA_ADAPTER_ES=${FEDORA_ADAPTER_ES:-//es/}
 
 RUN apk add --no-cache nodejs-npm && \
     apk add --no-cache --virtual .build-deps git && \
@@ -15,10 +17,19 @@ RUN apk add --no-cache nodejs-npm && \
     cd ${EMBER_BUILD_DIR} && \
     git clone ${EMBER_GIT_REPO} . && \
     git checkout ${EMBER_GIT_BRANCH} && \
-    chmod 700 /bin/entrypoint.sh && \
     npm install && \
-    npm install -g ember-cli
+    npm install -g ember-cli && \
+    ember build --environment=production
 
-WORKDIR /ember
+FROM nginx:1.13.12-alpine
+
+ENV EMBER_PORT=80
+COPY bin/entrypoint.sh /bin/
+COPY nginx-template.conf /
+
+RUN apk --no-cache add gettext && \
+    chmod a+x /bin/entrypoint.sh
+
+COPY --from=ember-builder /ember/dist/ /usr/share/nginx/html/
 
 ENTRYPOINT [ "/bin/entrypoint.sh" ]

--- a/ember/Dockerfile
+++ b/ember/Dockerfile
@@ -6,13 +6,13 @@ ARG EMBER_GIT_BRANCH
 ENV EMBER_GIT_BRANCH=${EMBER_GIT_BRANCH:-master} \
     EMBER_GIT_REPO=${EMBER_GIT_REPO:-https://github.com/OA-PASS/pass-ember} \
     EMBER_BUILD_DIR=/ember \
-    FEDORA_ADAPTER_BASE=${FEDORA_ADAPTER_BASE:-//fcrepo/rest/} \
-    FEDORA_ADAPTER_CONTEXT=${FEDORA_ADAPTER_CONTEXT:-https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.1.jsonld} \
-    FEDORA_ADAPTER_DATA=${FEDORA_ADAPTER_DATA:-http://example.org/pass/} \
-    FEDORA_ADAPTER_ES=${FEDORA_ADAPTER_ES:-//es/}
+    FEDORA_ADAPTER_BASE=/fcrepo/rest/ \
+    FEDORA_ADAPTER_CONTEXT=https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.2.jsonld \
+    FEDORA_ADAPTER_DATA=http://oapass.org/ns/pass# \
+    FEDORA_ADAPTER_ES=/es/ \
+    USER_SERVICE_URL=/pass-user-service/whoami
 
-RUN apk add --no-cache nodejs-npm && \
-    apk add --no-cache --virtual .build-deps git && \
+RUN apk add --no-cache nodejs-npm git && \
     mkdir -p ${EMBER_BUILD_DIR} && \
     cd ${EMBER_BUILD_DIR} && \
     git clone ${EMBER_GIT_REPO} . && \

--- a/ember/bin/entrypoint.sh
+++ b/ember/bin/entrypoint.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 
-ember server --port ${EMBER_PORT} --live-reload=false
+envsubst < /nginx-template.conf > /etc/nginx/conf.d/default.conf && \
+    nginx -g 'daemon off;'

--- a/ember/nginx-template.conf
+++ b/ember/nginx-template.conf
@@ -1,0 +1,21 @@
+server {
+    listen       ${EMBER_PORT} default_server;
+    server_name  _;
+
+    #charset utf-8;
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}

--- a/ember/nginx-template.conf
+++ b/ember/nginx-template.conf
@@ -10,7 +10,17 @@ server {
         index  index.html index.htm;
     }
 
-    #error_page  404              /404.html;
+    # This is important, any 404 will cause the ember
+    # app to re-load.  This is because all ember URLs
+    # (e.g. https://pass/grants/foo), when issued as an HTTP
+    # request, have nothing that 'serves' them.  Instead, the
+    # ember app, when loaded, inspects the URL and renders the
+    # correct page client-side.  So we want the ember app to load
+    # and parse all these 404 URLs.
+    # 
+    # Note, the equals sign means that a 200 is returned
+    # instead of a 404
+    error_page 404 = /index.html;
 
     # redirect server error pages to the static page /50x.html
     #


### PR DESCRIPTION
## Overview
* Uses `ember build` to deploy static assets behind nginx
* Bakes in relative URIs to ember build config

## To test:
* `docker-compose pull` (the ember image is pushed)
* `docker-compose up`
* Once up, go to `https://pass`

## Known issues
* It is desired to put ember at `/app` rather than `/.`  This cannot happen until OA-PASS/pass-ember#526 is resolved.  Until then, this retains the current behavior of having ember at `/`
* We need to add static PASS content to `pass-docker` at some point.  This is out of scope of this PR

Resolves #44 
