### PR TITLE
Secure elasticsearch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
 
   proxy:
     build: ./httpd-proxy/
-    image: oapass/httpd-proxy:20180618
+    image: oapass/httpd-proxy:20180618@sha256:fff8cff84a4821d52156c38d82d45910f4937806b857ece35571ea064665e92c
     container_name: proxy
     networks:
      - front
@@ -98,7 +98,7 @@ services:
 
   sp:
     build: ./sp/2.6.1
-    image: oapass/sp:20180618
+    image: oapass/sp:20180618@sha256:ed32c40bd99bd1c59e953520fb61dc2a633c7d2f7865a28cd71caefb5b20b527
     container_name: sp
     networks:
      - back

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
 
   proxy:
     build: ./httpd-proxy/
-    image: oapass/httpd-proxy:20180615@sha256:7e2b54361bb01e69e2d1ab48792dc71ef42159d31cab2c30dfd4b849d2db2858
+    image: oapass/httpd-proxy:20180618
     container_name: proxy
     networks:
      - front
@@ -98,7 +98,7 @@ services:
 
   sp:
     build: ./sp/2.6.1
-    image: oapass/sp:201806015@sha256:412938d0847ff19df3dc2d8f2bf62cf1c45a66fa7b8f845a5d471acc2b2ab7f9
+    image: oapass/sp:20180618
     container_name: sp
     networks:
      - back

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,7 +98,7 @@ services:
 
   sp:
     build: ./sp/2.6.1
-    image: oapass/sp:20180618@sha256:ed32c40bd99bd1c59e953520fb61dc2a633c7d2f7865a28cd71caefb5b20b527
+    image: oapass/sp:20180618@sha256:6999dc7a46c3fd3710bb215d562aca12463e8366eead899ec633b84e1456af3a
     container_name: sp
     networks:
      - back

--- a/httpd-proxy/etc-httpd/conf.d/httpd.conf
+++ b/httpd-proxy/etc-httpd/conf.d/httpd.conf
@@ -74,8 +74,8 @@ EECDH EDH+aRSA !aNULL !eNULL !LOW !3DES !MD5 !EXP !PSK !SRP !DSS !RC4"
     # Allow the pass Elasticsearch index to be searched as /es
     # Convert private Fedora URIs returned by Elasticsearch to public URIs.
     <Location /es>
-        ProxyPass http://elasticsearch:9200/pass/_search
-        ProxyPassReverse http://elasticsearch:9200/pass/_search
+        ProxyPass http://sp/es
+        ProxyPassReverse http://sp/es
 
         # Needed for Substitute to work. Turns off compression.
         RequestHeader unset Accept-Encoding

--- a/sp/2.6.1/etc-httpd/conf.d/sp.conf
+++ b/sp/2.6.1/etc-httpd/conf.d/sp.conf
@@ -45,5 +45,7 @@ AllowEncodedSlashes NoDecode
     ProxyPassReverse /app http://ember:81/app
     ProxyPass /app http://ember:81/app
 
+    ProxyPass /es http://elasticsearch:9200/pass/_search
+    ProxyPassReverse /es http://elasticsearch:9200/pass/_search
 
 </VirtualHost>

--- a/sp/2.6.1/etc-httpd/conf.d/sp.conf
+++ b/sp/2.6.1/etc-httpd/conf.d/sp.conf
@@ -25,6 +25,12 @@ AllowEncodedSlashes NoDecode
         require shib-session
     </Location>
 
+    <Location /es>
+        AuthType shibboleth
+        ShibRequestSetting requireSession 1
+        require shib-session
+    </Location>
+
     <Location /app>
         AuthType shibboleth
         ShibRequestSetting requireSession 1


### PR DESCRIPTION
Elasticsearch was not behind the shibboleth service provider, as it should be in production.  This PR fixes that.

## To test
* do a `docker-compose pull` followed by `docker-compose up`
* Go to `https://pass/es`.  It should prompt you to log in to shib (if it doesn't, restart and close browser)
* Go to `https://pass`, make sure nothing is broken with Ember