### PR TITLE
Disable tomcat authz, rely entirely on shib

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   fcrepo:
     build:
       context: ./fcrepo/4.7.5-SNAPSHOT
-    image: oapass/fcrepo:4.7.5-2.2-SNAPSHOT-9@698b79edcd3bb89ff832e261021f6e8688e69227b08e436b862874b37fc2740f
+    image: oapass/fcrepo:4.7.5-2.2-SNAPSHOT-9@sha256:698b79edcd3bb89ff832e261021f6e8688e69227b08e436b862874b37fc2740f
     container_name: fcrepo
     env_file: .env
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   fcrepo:
     build:
       context: ./fcrepo/4.7.5-SNAPSHOT
-    image: oapass/fcrepo:4.7.5-2.2-SNAPSHOT-8@sha256:75abb2ccc05040f65c4ca854871d7005ea6853c974d70d932823a6ad3b611d23
+    image: oapass/fcrepo:4.7.5-2.2-SNAPSHOT-9@698b79edcd3bb89ff832e261021f6e8688e69227b08e436b862874b37fc2740f
     container_name: fcrepo
     env_file: .env
     ports:
@@ -158,7 +158,7 @@ services:
       - assets
 
   assets:
-    image: birkland/assets:2018-06-19@sha256:5639825b668e982f248d35bb23a5d942a9353ca37c55cba06221e568e8445d88
+    image: birkland/assets:2018-06-20@sha256:a0c584ca72683178382fb6002330c034d10b1b91851202fabfaef9fb812b9863
     build: ./assets
     volumes:
       - passdata:/data

--- a/ember/Dockerfile
+++ b/ember/Dockerfile
@@ -11,6 +11,8 @@ ENV EMBER_GIT_BRANCH=${EMBER_GIT_BRANCH:-master} \
     FEDORA_ADAPTER_CONTEXT=https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.2.jsonld \
     FEDORA_ADAPTER_DATA=http://oapass.org/ns/pass# \
     FEDORA_ADAPTER_ES=/es/ \
+    FEDORA_ADAPTER_PASSWORD="" \    
+    FEDORA_ADAPTER_USER="" \
     USER_SERVICE_URL=/pass-user-service/whoami \
     EMBER_ROOT_URL=${EMBER_ROOT_URL:-/app/}
 

--- a/fcrepo/4.7.5-SNAPSHOT/Dockerfile
+++ b/fcrepo/4.7.5-SNAPSHOT/Dockerfile
@@ -22,7 +22,6 @@ FCREPO_JMS_CONFIGURATION=classpath:/spring/jms.xml \
 FCREPO_LOGBACK_LOCATION=webapps/fcrepo/WEB-INF/classes/logback.xml \
 FCREPO_PROPERTIES_MANAGEMENT=relaxed \
 SLF4J_VERSION=1.7.25 \
-DEBUG_PORT=5006 \
 DEBUG_ARG="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5006" \
 COMPACTION_URI=https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.2.jsonld \
 COMPACTION_PRELOAD_URI_PASS_STATIC_2_0=https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.0.jsonld \
@@ -36,7 +35,6 @@ JSONLD_CONTEXT_PERSIST=true \
 JSONLD_CONTEXT_MINIMAL=true \
 AUTHZ_USE_SHIB_HEADERS=true
 
-EXPOSE ${DEBUG_PORT}
 EXPOSE ${FCREPO_PORT}
 
 VOLUME /data

--- a/fcrepo/4.7.5-SNAPSHOT/WEB-INF/web.xml
+++ b/fcrepo/4.7.5-SNAPSHOT/WEB-INF/web.xml
@@ -77,14 +77,6 @@
     <url-pattern>/*</url-pattern>
   </filter-mapping>
 
-  <security-role>
-    <role-name>fedoraUser</role-name>
-  </security-role>
-
-  <security-role>
-    <role-name>fedoraAdmin</role-name>
-  </security-role>
-
   <security-constraint>
     <web-resource-collection>
       <url-pattern>/*</url-pattern>
@@ -98,8 +90,7 @@
       <http-method-omission>OPTIONS</http-method-omission>
     </web-resource-collection>
     <auth-constraint>
-      <role-name>fedoraUser</role-name>
-      <role-name>fedoraAdmin</role-name>
+      <role-name>**</role-name>
     </auth-constraint>
     <user-data-constraint>
       <transport-guarantee>NONE</transport-guarantee>

--- a/fcrepo/4.7.5-SNAPSHOT/conf/tomcat-users.xml
+++ b/fcrepo/4.7.5-SNAPSHOT/conf/tomcat-users.xml
@@ -1,16 +1,8 @@
 <tomcat-users>
   <!-- Create passwords with ./digest.sh -a sha-256 -h org.apache.catalina.realm.MessageDigestCredentialHandler [PASSWD] -->
-  <role rolename="fedoraUser" />
   <role rolename="fedoraAdmin" />
-  <user name="staff1" password="3a4384731fe845887c1307a668942ee37b516826a2c1085828a2e272bb71c544$1$36579ec0da60a5d1bbe0d6cde574400777b225e3e5939a8d5da9349d60020786" roles="fedoraUser" />
+  <role rolename="http://oapass.org/ns/roles/johnshopkins.edu#pass-backend" />
+  <user name="backend" password="d643a7be407e3f39a924b147a84f48397af41fe465f65b8506daac6cd84904dd$1$0e6a64c63d54a053607b156d48a34fca1ddcaedca71d743b8635f21d50a14fb2" roles="http://oapass.org/ns/roles/johnshopkins.edu#pass-backend" />
   <user name="bootstrap" password="d643a7be407e3f39a924b147a84f48397af41fe465f65b8506daac6cd84904dd$1$0e6a64c63d54a053607b156d48a34fca1ddcaedca71d743b8635f21d50a14fb2" roles="fedoraAdmin" />
-  <user name="admin" password="3a4384731fe845887c1307a668942ee37b516826a2c1085828a2e272bb71c544$1$36579ec0da60a5d1bbe0d6cde574400777b225e3e5939a8d5da9349d60020786" roles="fedoraUser" />
-  <user name="staff2" password="c08a7d142bc26f7fadc8667083aa160ba7f3673c0809b9547edb62e1b119088e$1$366a735c8ac0ebbbc98ef20e9657d1339bb6540182eeb355137e5b6975a068c0" roles="fedoraUser" />
-  <user name="faculty1" password="c1894208115e79c594e7f133140e637fc4d8c8e8d43cff969f92261d8488988f$1$27bee1d70a6bd6d40d7862d23cfeb5836dc0edc47f78da0da42d6a781b471395" roles="fedoraUser" />
-  <user name="faculty2" password="27387daea77f878f82b46c7e323db3245ce2fa079ab2c6f6c410bcbac4cb7da5$1$84f7dcbeb8fff3fa1bbcd50b41f272eec890f21749ce774a03742fa2d3a7399b" roles="fedoraUser" />
-  <user name="nih-user" password="27387daea77f878f82b46c7e323db3245ce2fa079ab2c6f6c410bcbac4cb7da5$1$84f7dcbeb8fff3fa1bbcd50b41f272eec890f21749ce774a03742fa2d3a7399b" roles="fedoraUser" />
-  <user name="ed-user" password="27387daea77f878f82b46c7e323db3245ce2fa079ab2c6f6c410bcbac4cb7da5$1$84f7dcbeb8fff3fa1bbcd50b41f272eec890f21749ce774a03742fa2d3a7399b" roles="fedoraUser" />
-  <user name="usaid-user" password="27387daea77f878f82b46c7e323db3245ce2fa079ab2c6f6c410bcbac4cb7da5$1$84f7dcbeb8fff3fa1bbcd50b41f272eec890f21749ce774a03742fa2d3a7399b" roles="fedoraUser" />
-  <user name="incomplete-nih-user" password="27387daea77f878f82b46c7e323db3245ce2fa079ab2c6f6c410bcbac4cb7da5$1$84f7dcbeb8fff3fa1bbcd50b41f272eec890f21749ce774a03742fa2d3a7399b" roles="fedoraUser" />
   <user name="fedoraAdmin" password="53253a46e9f2f74e6a1141f654eb0cb4a71624d0493e7289489ada0c6255a1f0$1$4ab46c609603537a8665e0dde3a6aaadae24914cb4d8cff10084bb1a7a45c91e" roles="fedoraAdmin" />
 </tomcat-users>


### PR DESCRIPTION
## Overview
 * Disables Tomcat authorization.  Previously, each user had to exist in Tomcat's user database (`tomcat-users.xml`) in order to access repository resources.  Now, we rely on shibboleth, and only use tomcat authorization for backend services.
* Adds acls to the `assets` container which grant access to the roles
  * `http://oapass.org/ns/roles/johnshopkins.edu#submitter`
  * `http://oapass.org/ns/roles/johnshopkins.edu#admin`
  * `http://oapass.org/ns/roles/johnshopkins.edu#pass-backend`
  * Individual users (their `User` uri) to give access to an individual

Individual users are granted access to 
  * Write to submissions for which they are the `user`
  * Read  Grants for which they are PIs or Co-PIs

Otherwise, the following default permissions apply:

```yaml
containers:
  - /:
      read:
        - submitter
        - admin
        - pass-backend

  - acls:
      write:
        - pass-backend

  - contributors:
      read: 
        - admin
      append:
        - submitter
      write:
        - pass-backend

  - deposits:
      read:
         - admin
         - submitter
      write: 
         - pass-backend

  - files:
      read: 
        - admin
      append:
        - submitter
      write:
        - pass-backend

  - grants:
      read:
        - admin
      write:
        - pass-backend

  - journals:
      read:
        - admin
      append:
        - submitter
      write:
        - pass-backend
        
  - policies:
      read:
        - submitter
        - admin
      write:
        - pass-backend
        
  - publications:
      read:
        - admin
      write:
        - submitter
        - pass-backend
        
  - publishers:
       read:
         - submitter
         - admin
       write:
         - pass-backend
         
  - repositories:
      read:
        - submitter
        - admin
      write:
        - pass-backend
   
  - repositoryCopies:
      read:
        - submitter
        - admin
      write:
        - pass-backend

  - submissions:
      read: 
        - admin
      append:
        - submitter
      write:
        - pass-backend
        
  - users:
     read:
       - submitter
       - admin
     write:
       - pass-backend
```