### PR TITLE
[DO NOT MERGE] Add unprotected landing page

### DIFF
--- a/.env
+++ b/.env
@@ -13,8 +13,8 @@ STATIC_HTML_GIT_BRANCH=6185bc5
 EMBER_PORT=81
 
 # Ember app build-time config
-EMBER_GIT_REPO=https://github.com/OA-PASS/pass-ember
-EMBER_GIT_BRANCH=876e097
+EMBER_GIT_REPO=https://github.com/jabrah/pass-ember
+EMBER_GIT_BRANCH=799e9e7
 EMBER_ROOT_URL=/app/
 
 # Fedora config

--- a/.env
+++ b/.env
@@ -7,7 +7,7 @@ STATIC_HTML_PORT=82
 
 # Static html server build-time config
 STATIC_HTML_GIT_REPO=https://github.com/karenhanson/pass-ui-static.git
-STATIC_HTML_GIT_BRANCH=67ec770
+STATIC_HTML_GIT_BRANCH=320c757
 
 # Ember app runtime config
 EMBER_PORT=81

--- a/.env
+++ b/.env
@@ -7,7 +7,7 @@ STATIC_HTML_PORT=82
 
 # Static html server build-time config
 STATIC_HTML_GIT_REPO=https://github.com/karenhanson/pass-ui-static.git
-STATIC_HTML_GIT_BRANCH=c55d8a2
+STATIC_HTML_GIT_BRANCH=c20926e
 
 # Ember app runtime config
 EMBER_PORT=81

--- a/.env
+++ b/.env
@@ -7,13 +7,13 @@ STATIC_HTML_PORT=82
 
 # Static html server build-time config
 STATIC_HTML_GIT_REPO=https://github.com/karenhanson/pass-ui-static.git
-STATIC_HTML_GIT_BRANCH=c20926e
+STATIC_HTML_GIT_BRANCH=67ec770
 
 # Ember app runtime config
 EMBER_PORT=81
 
 # Ember app build-time config
-EMBER_GIT_REPO=https://github.com/OA-PASS/pass-ember
+EMBER_GIT_REPO=https://github.com/karenhanson/pass-ember
 EMBER_GIT_BRANCH=876e097
 EMBER_ROOT_URL=/app/
 

--- a/.env
+++ b/.env
@@ -6,8 +6,8 @@ FTP_PORT=21
 STATIC_HTML_PORT=82
 
 # Static html server build-time config
-STATIC_HTML_GIT_REPO=https://github.com/OA-PASS/pass-ui-static.git
-STATIC_HTML_GIT_BRANCH=4af4140
+STATIC_HTML_GIT_REPO=https://github.com/jabrah/pass-ui-static.git
+STATIC_HTML_GIT_BRANCH=6185bc5
 
 # Ember app runtime config
 EMBER_PORT=81

--- a/.env
+++ b/.env
@@ -6,15 +6,15 @@ FTP_PORT=21
 STATIC_HTML_PORT=82
 
 # Static html server build-time config
-STATIC_HTML_GIT_REPO=https://github.com/jabrah/pass-ui-static.git
-STATIC_HTML_GIT_BRANCH=6185bc5
+STATIC_HTML_GIT_REPO=https://github.com/karenhanson/pass-ui-static.git
+STATIC_HTML_GIT_BRANCH=c55d8a2
 
 # Ember app runtime config
 EMBER_PORT=81
 
 # Ember app build-time config
-EMBER_GIT_REPO=https://github.com/jabrah/pass-ember
-EMBER_GIT_BRANCH=799e9e7
+EMBER_GIT_REPO=https://github.com/OA-PASS/pass-ember
+EMBER_GIT_BRANCH=876e097
 EMBER_ROOT_URL=/app/
 
 # Fedora config

--- a/.env
+++ b/.env
@@ -2,6 +2,13 @@
 FTP_HOST=ftpserver
 FTP_PORT=21
 
+# Static html server runtime config
+STATIC_HTML_PORT=82
+
+# Static html server build-time config
+STATIC_HTML_GIT_REPO=https://github.com/OA-PASS/pass-ui-static.git
+STATIC_HTML_GIT_BRANCH=4af4140
+
 # Ember app runtime config
 EMBER_PORT=81
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       args:
         STATIC_HTML_GIT_REPO: "${STATIC_HTML_GIT_REPO}"
         STATIC_HTML_GIT_BRANCH: "${STATIC_HTML_GIT_BRANCH}"
-    image: oapass/static-html:20180624-karenhanson-c55d8a2@sha256:fd6767c46310c265c05d64c0846e8da4e7eda2c726498cdf38881b857846bb00
+    image: oapass/static-html:20180624-karenhanson-c20926e@sha256:e6e7e73eea2dfa0b22dc1c7f30437e4ca700eb52ab8f19e8a568f5fe8b3c91e3
     container_name: static-html
     env_file: .env
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       args:
         EMBER_GIT_REPO: "${EMBER_GIT_REPO}"
         EMBER_GIT_BRANCH: "${EMBER_GIT_BRANCH}"
-    image: oapass/ember:20180623-876e097@sha256:1f86e57fa1b888d01eee8483d1045f232e84d0787c04582b2591a592bb042aa5
+    image: oapass/ember:20180624-799e9e7-jabrah@sha256:2d93bf0f9fba9a05b715b7d8ed4727e4b8c44a65187b33b104d7a549e7bfcc44
     container_name: ember
     env_file: .env
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       args:
         STATIC_HTML_GIT_REPO: "${STATIC_HTML_GIT_REPO}"
         STATIC_HTML_GIT_BRANCH: "${STATIC_HTML_GIT_BRANCH}"
-    image: oapass/static-html:20180624-karenhanson-c20926e@sha256:e6e7e73eea2dfa0b22dc1c7f30437e4ca700eb52ab8f19e8a568f5fe8b3c91e3
+    image: oapass/static-html:20180625-karenhanson-320c757@sha256:bdfeff7352d2ca0e5361311e413fb19a80f646ee9734b31e7e4168246f18472a
     container_name: static-html
     env_file: .env
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       args:
         EMBER_GIT_REPO: "${EMBER_GIT_REPO}"
         EMBER_GIT_BRANCH: "${EMBER_GIT_BRANCH}"
-    image: oapass/ember:20180623-876e097@sha256:1f86e57fa1b888d01eee8483d1045f232e84d0787c04582b2591a592bb042aa5
+    image: oapass/ember:20180624-67ec770-karenhanson@sha256:1f86e57fa1b888d01eee8483d1045f232e84d0787c04582b2591a592bb042aa5
     container_name: ember
     env_file: .env
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,21 @@ services:
     networks:
       - back
 
+  static-html:
+    build:
+      context: ./static-html
+      args:
+        STATIC_HTML_GIT_REPO: "${STATIC_HTML_GIT_REPO}"
+        STATIC_HTML_GIT_BRANCH: "${STATIC_HTML_GIT_BRANCH}"
+    image: oapass/static-html:20180622-4af4140@sha256:544d8a9d5c6164f39b3dfc16917b979a51a5e580630cf41528e53d0163d7eac1
+    container_name: static-html
+    env_file: .env
+    ports:
+      - "${STATIC_HTML_PORT}:${STATIC_HTML_PORT}"
+    networks:
+      - back
+      - front
+
   ftpserver:
     build: ./ftpserver/0.0.1-demo
     image: oapass/ftpserver@sha256:145f7e3bb494deeb1e1c587f34f0f54649f22d6ef0c107bacd022b0308146ddb
@@ -59,7 +74,7 @@ services:
 
   proxy:
     build: ./httpd-proxy/
-    image: oapass/httpd-proxy:20180618@sha256:fff8cff84a4821d52156c38d82d45910f4937806b857ece35571ea064665e92c
+    image: oapass/httpd-proxy:20180622@sha256:423b358d177cb903316b1449ed2d25357137e85a9b3f4d270e30e56354c54c0e
     container_name: proxy
     networks:
      - front

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       args:
         STATIC_HTML_GIT_REPO: "${STATIC_HTML_GIT_REPO}"
         STATIC_HTML_GIT_BRANCH: "${STATIC_HTML_GIT_BRANCH}"
-    image: oapass/static-html:20180622-4af4140@sha256:544d8a9d5c6164f39b3dfc16917b979a51a5e580630cf41528e53d0163d7eac1
+    image: oapass/static-html:20180622-jabrah-6185bc5@sha256:740974da027fe74f051f1abc58318e089536d85fc63589d2fff4f51229951100
     container_name: static-html
     env_file: .env
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       args:
         EMBER_GIT_REPO: "${EMBER_GIT_REPO}"
         EMBER_GIT_BRANCH: "${EMBER_GIT_BRANCH}"
-    image: oapass/ember:20180624-799e9e7-jabrah@sha256:2d93bf0f9fba9a05b715b7d8ed4727e4b8c44a65187b33b104d7a549e7bfcc44
+    image: oapass/ember:20180623-876e097@sha256:1f86e57fa1b888d01eee8483d1045f232e84d0787c04582b2591a592bb042aa5
     container_name: ember
     env_file: .env
     networks:
@@ -52,7 +52,7 @@ services:
       args:
         STATIC_HTML_GIT_REPO: "${STATIC_HTML_GIT_REPO}"
         STATIC_HTML_GIT_BRANCH: "${STATIC_HTML_GIT_BRANCH}"
-    image: oapass/static-html:20180622-jabrah-6185bc5@sha256:740974da027fe74f051f1abc58318e089536d85fc63589d2fff4f51229951100
+    image: oapass/static-html:20180624-karenhanson-c55d8a2@sha256:fd6767c46310c265c05d64c0846e8da4e7eda2c726498cdf38881b857846bb00
     container_name: static-html
     env_file: .env
     ports:

--- a/httpd-proxy/etc-httpd/conf.d/httpd.conf
+++ b/httpd-proxy/etc-httpd/conf.d/httpd.conf
@@ -101,6 +101,10 @@ EECDH EDH+aRSA !aNULL !eNULL !LOW !3DES !MD5 !EXP !PSK !SRP !DSS !RC4"
     ProxyPass /app http://sp/app
     ProxyPassReverse /app http://sp/app
 
+    # Static pages
+    ProxyPass / http://static-html:82/
+    ProxyPassReverse / http://static-html:82/
+
 </VirtualHost>
 
 <IfModule log_config_module>

--- a/static-html/Dockerfile
+++ b/static-html/Dockerfile
@@ -1,0 +1,27 @@
+FROM alpine:3.7 as static-builder
+
+ARG STATIC_HTML_GIT_REPO
+ARG STATIC_HTML_GIT_BRANCH
+
+ENV STATIC_HTML_DIR=/html
+
+RUN apk add --no-cache git && \
+    mkdir ${STATIC_HTML_DIR}
+
+RUN cd ${STATIC_HTML_DIR} && \
+    git clone ${STATIC_HTML_GIT_REPO} . && \
+    git checkout ${STATIC_HTML_GIT_BRANCH}
+
+FROM nginx:1.13.12-alpine
+
+ENV STATIC_HTML_PORT=80 
+
+COPY --from=static-builder /html/ /usr/share/nginx/html/
+COPY bin/entrypoint.sh /bin/
+COPY nginx-template.conf /
+
+RUN apk --no-cache add gettext && \
+    chmod a+x /bin/entrypoint.sh
+    
+
+ENTRYPOINT [ "/bin/entrypoint.sh" ]

--- a/static-html/bin/entrypoint.sh
+++ b/static-html/bin/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+envsubst < /nginx-template.conf > /etc/nginx/conf.d/default.conf && \
+    nginx -g 'daemon off;'

--- a/static-html/nginx-template.conf
+++ b/static-html/nginx-template.conf
@@ -1,0 +1,21 @@
+server {
+    listen       ${STATIC_HTML_PORT} default_server;
+    server_name  _;
+
+    #charset utf-8;
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}


### PR DESCRIPTION
## Overview
* Adds the contents of `pass-ui-static` to docker image, served by nginx
* Proxies requests from `https:/pass` to the landing page(s) without requiring shib authentication


## To test:
* do `docker-compose pull`
* ~At a minimum, do `docker-compose up proxy static-html`; or~ just do a regular `docker-compose up`.  
* Navigate to `https://pass`, and look around.  You should see the landing page

## Known issues
* Links are broken; I'm not sure anything can be done about that other than modifying the contents of `pass-ui-static`.