### PR TITLE
Added support for alternate entrypoint for AWS

### DIFF
--- a/deposit-services/0.0.6-2.2/Dockerfile
+++ b/deposit-services/0.0.6-2.2/Dockerfile
@@ -44,8 +44,11 @@ EXPOSE ${DEPOSIT_DEBUG_PORT}
 #java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap
 # spring.activemq.broker-url
 
+COPY bin/aws_entrypoint.sh /bin/
 RUN apk update && \
-    apk add --no-cache ca-certificates wget && \
+    apk add --no-cache ca-certificates wget python py-pip && \
+    pip install awscli && \
+    chmod 700 /bin/aws_entrypoint.sh && \
     wget -O deposit-messaging.jar \
         https://github.com/OA-PASS/nihms-submission/releases/download/deposit-services-${DEPOSIT_SERVICES_VERSION}/deposit-messaging-${DEPOSIT_SERVICES_VERSION}-${JSONLD_CONTEXT_VERSION}.jar
 

--- a/deposit-services/0.0.6-2.2/bin/aws_entrypoint.sh
+++ b/deposit-services/0.0.6-2.2/bin/aws_entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+aws s3 cp s3://pass-configuration-files/entrypoints/depositservices.sh /bin/depositservices_entrypoint.sh
+
+if [ -f /bin/depositservices_entrypoints.sh ]; then
+    echo "depositservices.sh found...running"
+    chmod 700 /bin/depositservices_entrypoint.sh
+    /bin/depositservices_entrypoint.sh
+else
+    java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -jar deposit-messaging.jar listen
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -173,7 +173,7 @@ services:
 
   deposit:
     build: ./deposit-services/0.0.6-2.2
-    image: oapass/deposit-services:0.0.6-2.2@sha256:e152e4b77bd86b09fc293b221bc25fa554e489bb394c362bbdf994ac5e30b6cb
+    image: oapass/deposit-services:0.0.6-2.2-1@sha256:4684c5607298d98826768f72a61082427619b90a4c6fdc51174f737c2015d7c5
     container_name: deposit
     env_file: .env
     environment:


### PR DESCRIPTION
This PR adds support for an alternate entrypoint for Deposit Services. It does the following:

• Installs python and py-pip via apk
• Installs awscli via pip
• Copies /bin/* to /bin/
• Sets mode on aws_entrypoint.sh to 700

The entrypoint will reach out to s3 and copy a script to /bin. If that succeeds, it will set the mode and run it, otherwise it will run the entrypoint + cmd in the original Dockerfile.