### PR TITLE
Add authorization service

### DIFF
--- a/.env
+++ b/.env
@@ -71,3 +71,6 @@ PI_LOG_LEVEL=info
 DEPOSIT_DEBUG_PORT=5007
 PASS_DEPOSIT_QUEUE_SUBMISSION_NAME=Consumer.submission.VirtualTopic.pass.docker
 PASS_DEPOSIT_QUEUE_DEPOSIT_NAME=Consumer.deposit.VirtualTopic.pass.docker
+
+# Authorization Listener
+PASS_AUTHZ_QUEUE=Consumer.authz.VirtualTopic.pass.docker

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ There are four users that can log in via Shibboleth. These can be used to log in
 * `ed-user` Person with DOE gtants
 * `usaid-user` Person with USAID grants
 * `incomplete-nih-user` Person with incomplete submissions harvested from NIHMS
+* `admin` Grant admin
 
 
 <h2><a id="stop" href="#stop">Stopping</a></h2>

--- a/authz/Dockerfile
+++ b/authz/Dockerfile
@@ -1,0 +1,21 @@
+FROM openjdk:8u151-jre-alpine3.7@sha256:795d1c079217bdcbff740874b78ddea80d5df858b3999951a33871ee61de15ce
+
+ENV VERSION=0.1.0-SNAPSHOT \
+    AUTHZ_MAX_ATTEMPTS=20 \
+    PASS_BACKEND_ROLE=http://oapass.org/ns/roles/johnshopkins.edu#pass-backend \
+    PASS_GRANTADMIN_ROLE=http://oapass.org/ns/roles/johnshopkins.edu#admin \
+    PASS_SUBMITTER_ROLE=http://oapass.org/ns/roles/johnshopkins.edu#submitter
+
+
+WORKDIR /app
+
+ADD wait_and_start.sh /app
+
+RUN apk add --no-cache ca-certificates wget gettext curl && \
+    wget https://github.com/OA-PASS/pass-authz/releases/download/${VERSION}/pass-authz-tools-${VERSION}-listener-exe.jar && \
+    echo "6c1c26783a35dcba3dab480418d8bca51f47acf1 *pass-authz-tools-${VERSION}-listener-exe.jar" \
+        | sha1sum -c -  && \
+    rm -rf /var/cache/apk/ && \
+    chmod 700 wait_and_start.sh 
+
+CMD ./wait_and_start.sh pass-authz-tools-${VERSION}-listener-exe.jar

--- a/authz/wait_and_start.sh
+++ b/authz/wait_and_start.sh
@@ -1,0 +1,48 @@
+#! /bin/sh
+
+# Argument should be indexer jar to run.
+# Wait until we get a 200 from Fedora or fail some number of times.
+# Then start indexer.
+
+if [ -z "$JMS_BROKERURL" ]; then
+    export JMS_BROKERURL=${SPRING_ACTIVEMQ_BROKER_URL}
+fi
+
+if [ -z "$JMS_USERNAME" ]; then
+    export JMS_USERNAME=${SPRING_ACTIVEMQ_USER}
+fi
+
+if [ -z "$JMS_PASSWORD" ]; then
+    export JMS_PASSWORD=${SPRING_ACTIVEMQ_PASSWORD}
+fi
+
+function wait_until_fedora_up {
+    CMD="curl -I -u ${PASS_FEDORA_USER}:${PASS_FEDORA_PASSWORD} --write-out %{http_code} --silent -o /dev/stderr ${PASS_FEDORA_BASEURL}"
+    echo "Waiting for response from Fedora via ${CMD}"
+
+    RESULT=0
+    max=${AUTHZ_MAX_ATTEMPTS}
+    i=1
+    
+    until [ ${RESULT} -eq 200 ]
+    do
+        sleep 5
+        
+        RESULT=$(${CMD})
+
+        if [ $i -eq $max ]
+        then
+           echo "Reached max attempts"
+           exit 1
+        fi
+
+        i=$((i+1))
+        echo "Trying again, result was ${RESULT}"
+    done
+    
+    echo "Fedora is up."
+}
+
+wait_until_fedora_up
+
+exec java -jar "$1"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   fcrepo:
     build:
       context: ./fcrepo/4.7.5-SNAPSHOT
-    image: oapass/fcrepo:4.7.5-2.2-SNAPSHOT-9@sha256:698b79edcd3bb89ff832e261021f6e8688e69227b08e436b862874b37fc2740f
+    image: oapass/fcrepo:4.7.5-2.2-SNAPSHOT-10@sha256:fef548b284f4a52bfe6530b8295f6dadd4f3cfe1ed330c564983a7382fd832d0
     container_name: fcrepo
     env_file: .env
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,7 +159,7 @@ services:
       - assets
 
   assets:
-    image: birkland/assets:2018-06-20@sha256:a0c584ca72683178382fb6002330c034d10b1b91851202fabfaef9fb812b9863
+    image: birkland/assets:2018-06-24@sha256:3f2214373afe1791235487e153f58c4c3e4f4788a9d2d9ef35d6f8ca2a41bbbb
     build: ./assets
     volumes:
       - passdata:/data
@@ -185,6 +185,14 @@ services:
 # To override packager configuration, create a file named './packagers.properties', edit to suit, and uncomment below
 #    volumes:
 #      - ./packagers.properties:/packagers.properties
+
+  authz:
+    build: ./authz
+    image: oapass/authz:0.1.0-2.2-SNAPSHOT@sha256:7b82b6a348794f5aff4b91a90dcfcbeb1a8fbffee6a7e1bd337f12909480a86f
+    container_name: authz
+    env_file: .env
+    networks:
+      - back
 
 volumes:
   passdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,7 +92,7 @@ services:
 
   ldap:
     build: ./ldap/
-    image: oapass/ldap:20180609@sha256:a90044c91d70735f8a0b10cf63151d109fbb87fd775d48f5bc02a91c04fbd882
+    image: oapass/ldap:20180625@sha256:91775d0aa6ed7767aa25345355cea22c9136a8be4dac564ecc9c44870ab00af5
     container_name: ldap
     networks:
      - back
@@ -190,6 +190,13 @@ services:
     build: ./authz
     image: oapass/authz:0.1.0-2.2-SNAPSHOT@sha256:7b82b6a348794f5aff4b91a90dcfcbeb1a8fbffee6a7e1bd337f12909480a86f
     container_name: authz
+    env_file: .env
+    networks:
+      - back
+  
+  testing:
+    image: oapass/test:20180625@sha256:15b9a579eb46cfaf823334564078feb1d9f722a32fefb37073b7cd9081cd21f8
+    build: ./testing
     env_file: .env
     networks:
       - back

--- a/fcrepo/4.7.5-SNAPSHOT/Dockerfile
+++ b/fcrepo/4.7.5-SNAPSHOT/Dockerfile
@@ -2,7 +2,7 @@ FROM tomcat:8.5.31-jre8-alpine@sha256:f9a53932a3cc61ea3a1c307e7bf60897bce356c60c
 
 ENV FCREPO_VERSION=4.7.5 \
 JSONLD_ADDON_VERSION=0.0.6-SNAPSHOT \
-PASS_AUTHZ_VERSION=0.0.3-SNAPSHOT \
+PASS_AUTHZ_VERSION=0.1.0-SNAPSHOT \
 JMS_ADDON_VERSION=0.0.2 \
 FCREPO_HOME=${CATALINA_HOME}/fcrepo4-data \
 FCREPO_HOST=fcrepo \
@@ -61,11 +61,11 @@ RUN apk update && \
         | sha1sum -c -  && \
     wget -O ${CATALINA_HOME}/lib/pass-authz-filters-shaded.jar \
         https://github.com/OA-PASS/pass-authz/releases/download/${PASS_AUTHZ_VERSION}/pass-authz-filters-${PASS_AUTHZ_VERSION}-shaded.jar && \
-    echo "dfaa302043005f8c6201459d79997e9d3009daf1 *${CATALINA_HOME}/lib/pass-authz-filters-shaded.jar" \
+    echo "22c63f5358617d4eb0ab4b629bd21a69b01517c9 *${CATALINA_HOME}/lib/pass-authz-filters-shaded.jar" \
         | sha1sum -c -  && \
     wget -O ${CATALINA_HOME}/webapps/pass-user-service.war \
         https://github.com/OA-PASS/pass-authz/releases/download/${PASS_AUTHZ_VERSION}/pass-user-service-${PASS_AUTHZ_VERSION}.war && \
-    echo "145c64206c3d63a9f9ca9eb82f9006522239643d *${CATALINA_HOME}/webapps/pass-user-service.war" \
+    echo "d49a7cfa94390cff66828ae5f33eecc79642e5cd *${CATALINA_HOME}/webapps/pass-user-service.war" \
         | sha1sum -c -  && \
     mkdir ${CATALINA_HOME}/webapps/pass-user-service && \
     unzip ${CATALINA_HOME}/webapps/pass-user-service.war -d ${CATALINA_HOME}/webapps/pass-user-service  && \

--- a/fcrepo/4.7.5-SNAPSHOT/conf/tomcat-users.xml
+++ b/fcrepo/4.7.5-SNAPSHOT/conf/tomcat-users.xml
@@ -2,7 +2,7 @@
   <!-- Create passwords with ./digest.sh -a sha-256 -h org.apache.catalina.realm.MessageDigestCredentialHandler [PASSWD] -->
   <role rolename="fedoraAdmin" />
   <role rolename="http://oapass.org/ns/roles/johnshopkins.edu#pass-backend" />
-  <user name="backend" password="d643a7be407e3f39a924b147a84f48397af41fe465f65b8506daac6cd84904dd$1$0e6a64c63d54a053607b156d48a34fca1ddcaedca71d743b8635f21d50a14fb2" roles="http://oapass.org/ns/roles/johnshopkins.edu#pass-backend" />
+  <user name="backend" password="53253a46e9f2f74e6a1141f654eb0cb4a71624d0493e7289489ada0c6255a1f0$1$4ab46c609603537a8665e0dde3a6aaadae24914cb4d8cff10084bb1a7a45c91e" roles="http://oapass.org/ns/roles/johnshopkins.edu#pass-backend" />
   <user name="bootstrap" password="d643a7be407e3f39a924b147a84f48397af41fe465f65b8506daac6cd84904dd$1$0e6a64c63d54a053607b156d48a34fca1ddcaedca71d743b8635f21d50a14fb2" roles="fedoraAdmin" />
   <user name="fedoraAdmin" password="53253a46e9f2f74e6a1141f654eb0cb4a71624d0493e7289489ada0c6255a1f0$1$4ab46c609603537a8665e0dde3a6aaadae24914cb4d8cff10084bb1a7a45c91e" roles="fedoraAdmin" />
 </tomcat-users>

--- a/ldap/users.ldif
+++ b/ldap/users.ldif
@@ -117,4 +117,18 @@ employeeNumber: 00003088
 displayName: Usai Duser
 employeeType: FACULTY
 
+dn: uid=admin,ou=People,dc=pass
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+objectClass: inetOrgPerson
+givenName: Grant
+sn: Admin
+cn: Grant Admin
+mail: grand-admin@jhu.edu
+userPassword: moo
+employeeNumber: admin0001
+displayName: Grant Admin
+employeeType: STAFF
+
 

--- a/testing/Dockerfile
+++ b/testing/Dockerfile
@@ -1,0 +1,12 @@
+FROM alpine:3.7
+
+WORKDIR /app
+
+ADD load_admin.sh /app
+ADD admin.json /app
+
+RUN apk add --no-cache ca-certificates wget gettext curl && \
+    rm -rf /var/cache/apk/ && \
+    chmod 700 load_admin.sh 
+
+CMD ./load_admin.sh 

--- a/testing/admin.json
+++ b/testing/admin.json
@@ -1,0 +1,7 @@
+{
+  "@id" : "",
+  "@type" : "User",
+  "localKey" : "admin0001",
+  "roles" : [ "admin" ],
+  "@context" : "https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.2.jsonld"
+}

--- a/testing/load_admin.sh
+++ b/testing/load_admin.sh
@@ -1,0 +1,34 @@
+#! /bin/sh
+
+function wait_until_fedora_up {
+    CMD="curl -I -u ${PASS_FEDORA_USER}:${PASS_FEDORA_PASSWORD} --write-out %{http_code} --silent -o /dev/stderr ${PASS_FEDORA_BASEURL}"
+    echo "Waiting for response from Fedora via ${CMD}"
+
+    RESULT=0
+    max=${AUTHZ_MAX_ATTEMPTS}
+    i=1
+    
+    until [ ${RESULT} -eq 200 ]
+    do
+        sleep 5
+        
+        RESULT=$(${CMD})
+
+        if [ $i -eq $max ]
+        then
+           echo "Reached max attempts"
+           exit 1
+        fi
+
+        i=$((i+1))
+        echo "Trying again, result was ${RESULT}"
+    done
+    
+    echo "Fedora is up."
+}
+
+wait_until_fedora_up
+
+curl -v -i -# -u  ${PASS_FEDORA_USER}:${PASS_FEDORA_PASSWORD} -X POST -H "Content-Type: application/ld+json" --data-binary "@admin.json" ${PASS_FEDORA_BASEURL}users
+
+


### PR DESCRIPTION
## Overview
  * Adds an `authz` service that listens for Fedora messages and updates permissions as necessary when grants and submissions are created or updated
 * Updates the `assets` container to contain fine-grained permissions that include granting grant admins access
 * Adds an `admin` shibboleth user, and a `testing` container to add that new user to the repository, so that grant admins can log in (and also so as not to spoil the `assets` container with test data)

## To test
To really test this involves logging in as different users - the best way I've found to do that is to close down the browser completely, then re-start in incognito mode for each user.

* do `docker-compose pull` and `docker-compose up`
* log in as a user (e.g. `nih-user`), and complete a submission.  Once successful, follow the link "A detailed summary of your submission can be seen here"
* View the submission resource in Fedora.  What I do is copy the part of the url after `/pass/app/submissions/, then go to [urldecoder.org](https://www.urldecoder.org/), paste it in, and get the decoded submission resource URL.  Past that URL in the browser.  ALSO COPY IT, as you'll be using it in later steps.
* You should see the resource, but _not_ any buttons to delete or modify it.  It is read-only as far as the submitter is concerned.
* Now click on the grant (`pass:grants`).  It too should be read-only.  COPY THIS GRANT URL TOO
* Now go back to the submission, and click on the publication (`pass:publication`).   Publications are writable by anybody.  Now you _should_ see the UI options to update/delete it.

Now close your browser and log in as somebody else, maybe `incomplete-nih-user`.
* Go to the submission URL you copied earlier.  You should get a 403 Forbidden error
* Do the same with the grant URL.  Same 403 Forbidden

Now close your browser and log in as `admin`.  This is a grant admin
NOTE:  there is a bug in the `testing` image that won't be fixed right away.  As a workaround, if login as `admin` fails, do `docker-compose up testing` manually.  This will re-create the admin user.

* Go to the submission URL you copied earlier.  You should be able to see it again, and it's still read-only
* Same for the grant URL.  You should see it as read-only.

