### PR TITLE
Bump to latest ember and static-html images

### DIFF
--- a/.env
+++ b/.env
@@ -7,14 +7,14 @@ STATIC_HTML_PORT=82
 
 # Static html server build-time config
 STATIC_HTML_GIT_REPO=https://github.com/OA-PASS/pass-ui-static.git
-STATIC_HTML_GIT_BRANCH=7a50084053d9facecd9bc27a363db9af0fd76eb8
+STATIC_HTML_GIT_BRANCH=cc005a30cf0f26715f8b3df14747f62d615854d6
 
 # Ember app runtime config
 EMBER_PORT=81
 
 # Ember app build-time config
 EMBER_GIT_REPO=https://github.com/OA-PASS/pass-ember
-EMBER_GIT_BRANCH=98b53a1f027e478a5959dc99e09e129c6aa4b29b
+EMBER_GIT_BRANCH=84dbe9566b033971766a7a9ac47c43a611d563bb
 EMBER_ROOT_URL=/app/
 
 # Fedora config

--- a/.env
+++ b/.env
@@ -14,7 +14,7 @@ EMBER_PORT=81
 
 # Ember app build-time config
 EMBER_GIT_REPO=https://github.com/OA-PASS/pass-ember
-EMBER_GIT_BRANCH=29dd183593d75267e587dbcab4d262553305b265
+EMBER_GIT_BRANCH=def62bf28ddcb36887982e17663036d5b2364ac2
 EMBER_ROOT_URL=/app/
 
 # Fedora config

--- a/.env
+++ b/.env
@@ -7,14 +7,14 @@ STATIC_HTML_PORT=82
 
 # Static html server build-time config
 STATIC_HTML_GIT_REPO=https://github.com/OA-PASS/pass-ui-static.git
-STATIC_HTML_GIT_BRANCH=cc005a30cf0f26715f8b3df14747f62d615854d6
+STATIC_HTML_GIT_BRANCH=50b17b97204c8e18e046933824d968cfbb60fb49
 
 # Ember app runtime config
 EMBER_PORT=81
 
 # Ember app build-time config
 EMBER_GIT_REPO=https://github.com/OA-PASS/pass-ember
-EMBER_GIT_BRANCH=84dbe9566b033971766a7a9ac47c43a611d563bb
+EMBER_GIT_BRANCH=29dd183593d75267e587dbcab4d262553305b265
 EMBER_ROOT_URL=/app/
 
 # Fedora config

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       args:
         EMBER_GIT_REPO: "${EMBER_GIT_REPO}"
         EMBER_GIT_BRANCH: "${EMBER_GIT_BRANCH}"
-    image: oapass/ember:20180706-29dd183@sha256:ecff22390622c27bf2b0bedaebe4a1301ed5bdeeb4b4d9685f08911bbbadf30a
+    image: oapass/ember:20180710-def62bf@sha256:d61d5dd96bbe792434a15e5cf7b04ddd8010ed976d97353af0fc3682097dee98
     container_name: ember
     env_file: .env
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       args:
         EMBER_GIT_REPO: "${EMBER_GIT_REPO}"
         EMBER_GIT_BRANCH: "${EMBER_GIT_BRANCH}"
-    image: oapass/ember:20180630-84dbe95@sha256:11fd184cbfd88d67a3da9bf966f5e5784e04a31404df1b8e78646f3ff535f569
+    image: oapass/ember:20180706-29dd183@sha256:ecff22390622c27bf2b0bedaebe4a1301ed5bdeeb4b4d9685f08911bbbadf30a
     container_name: ember
     env_file: .env
     networks:
@@ -52,7 +52,7 @@ services:
       args:
         STATIC_HTML_GIT_REPO: "${STATIC_HTML_GIT_REPO}"
         STATIC_HTML_GIT_BRANCH: "${STATIC_HTML_GIT_BRANCH}"
-    image: oapass/static-html:20180629-cc005a3@sha256:bc133bb38b334e2c8d87dbe4c7b243963408ec613c36fd7b57f935fe052ec7dc
+    image: oapass/static-html:20180706-50b17b9@sha256:96361a5ffea55c09a60ad2e27697b8430e76a71e78d43a0c7892bddc29c96772
     container_name: static-html
     env_file: .env
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       args:
         EMBER_GIT_REPO: "${EMBER_GIT_REPO}"
         EMBER_GIT_BRANCH: "${EMBER_GIT_BRANCH}"
-    image: oapass/ember:20180629-98b53a1@sha256:2ef51acc561bb43f65736bfc6ee1f8b927920677194099ae87618c679d931e6e
+    image: oapass/ember:20180630-84dbe95@sha256:11fd184cbfd88d67a3da9bf966f5e5784e04a31404df1b8e78646f3ff535f569
     container_name: ember
     env_file: .env
     networks:
@@ -52,7 +52,7 @@ services:
       args:
         STATIC_HTML_GIT_REPO: "${STATIC_HTML_GIT_REPO}"
         STATIC_HTML_GIT_BRANCH: "${STATIC_HTML_GIT_BRANCH}"
-    image: oapass/static-html:20180629-7a50084@sha256:30805d485830d08161a1d4b4fb73c6c070174cfd529deb6edbcd4ef3dd286022
+    image: oapass/static-html:20180629-cc005a3@sha256:bc133bb38b334e2c8d87dbe4c7b243963408ec613c36fd7b57f935fe052ec7dc
     container_name: static-html
     env_file: .env
     ports:


### PR DESCRIPTION
### static-html changes:
* adds a red banner to top of page and removes badly positioned footer if you try to go to the site with IE, tells you to use other browsers 
* Format error pages to include icon, simplified text

### ember changes: 
* http encodes file names so high unicode chars don't cause failed file upload
* handles decoded fedora rest paths after /submissions/ or /grants/ (when redirected back from login page, this was getting decoded and causing errors)
* removes some console logs for error handler
* Format error pages to include icon, simplified text
* Redirects errors with payload of "Unauthorized" to 401 (needs PR #103 to work with pass-docker)