### PR TITLE
Update authz, static-html, and ember versions to latest

### DIFF
--- a/.env
+++ b/.env
@@ -7,14 +7,14 @@ STATIC_HTML_PORT=82
 
 # Static html server build-time config
 STATIC_HTML_GIT_REPO=https://github.com/OA-PASS/pass-ui-static.git
-STATIC_HTML_GIT_BRANCH=7a50084053d9facecd9bc27a363db9af0fd76eb8
+STATIC_HTML_GIT_BRANCH=50b17b97204c8e18e046933824d968cfbb60fb49
 
 # Ember app runtime config
 EMBER_PORT=81
 
 # Ember app build-time config
 EMBER_GIT_REPO=https://github.com/OA-PASS/pass-ember
-EMBER_GIT_BRANCH=98b53a1f027e478a5959dc99e09e129c6aa4b29b
+EMBER_GIT_BRANCH=def62bf28ddcb36887982e17663036d5b2364ac2
 EMBER_ROOT_URL=/app/
 
 # Fedora config

--- a/authz/Dockerfile
+++ b/authz/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8u151-jre-alpine3.7@sha256:795d1c079217bdcbff740874b78ddea80d5df858b3999951a33871ee61de15ce
 
-ENV VERSION=0.1.0-SNAPSHOT \
+ENV VERSION=0.1.1-SNAPSHOT \
     AUTHZ_MAX_ATTEMPTS=20 \
     PASS_BACKEND_ROLE=http://oapass.org/ns/roles/johnshopkins.edu#pass-backend \
     PASS_GRANTADMIN_ROLE=http://oapass.org/ns/roles/johnshopkins.edu#admin \
@@ -13,7 +13,7 @@ ADD wait_and_start.sh /app
 
 RUN apk add --no-cache ca-certificates wget gettext curl && \
     wget https://github.com/OA-PASS/pass-authz/releases/download/${VERSION}/pass-authz-tools-${VERSION}-listener-exe.jar && \
-    echo "6c1c26783a35dcba3dab480418d8bca51f47acf1 *pass-authz-tools-${VERSION}-listener-exe.jar" \
+    echo "fa40cc62e00ea705862cdaf1a1f0f4ad5c734e04 *pass-authz-tools-${VERSION}-listener-exe.jar" \
         | sha1sum -c -  && \
     rm -rf /var/cache/apk/ && \
     chmod 700 wait_and_start.sh 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       args:
         EMBER_GIT_REPO: "${EMBER_GIT_REPO}"
         EMBER_GIT_BRANCH: "${EMBER_GIT_BRANCH}"
-    image: oapass/ember:20180629-98b53a1@sha256:2ef51acc561bb43f65736bfc6ee1f8b927920677194099ae87618c679d931e6e
+    image: oapass/ember:20180710-def62bf@sha256:d61d5dd96bbe792434a15e5cf7b04ddd8010ed976d97353af0fc3682097dee98
     container_name: ember
     env_file: .env
     networks:
@@ -52,7 +52,7 @@ services:
       args:
         STATIC_HTML_GIT_REPO: "${STATIC_HTML_GIT_REPO}"
         STATIC_HTML_GIT_BRANCH: "${STATIC_HTML_GIT_BRANCH}"
-    image: oapass/static-html:20180629-7a50084@sha256:30805d485830d08161a1d4b4fb73c6c070174cfd529deb6edbcd4ef3dd286022
+    image: oapass/static-html:20180706-50b17b9@sha256:96361a5ffea55c09a60ad2e27697b8430e76a71e78d43a0c7892bddc29c96772
     container_name: static-html
     env_file: .env
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   fcrepo:
     build:
       context: ./fcrepo/4.7.5-SNAPSHOT
-    image: oapass/fcrepo:4.7.5-2.2-SNAPSHOT-11@sha256:48e4aa7c6cb5ab384815e1e88e8421f5b6978b52764bcc050781882f188aa3e5
+    image: oapass/fcrepo:4.7.5-2.2-SNAPSHOT-12@sha256:944c9d26a45283dfe14189b6da0e83ce72f824cfe0306f3f2951c97e706c51d9
     container_name: fcrepo
     env_file: .env
     ports:
@@ -203,7 +203,7 @@ services:
 
   authz:
     build: ./authz
-    image: oapass/authz:0.1.0-2.2-SNAPSHOT@sha256:7b82b6a348794f5aff4b91a90dcfcbeb1a8fbffee6a7e1bd337f12909480a86f
+    image: oapass/authz:0.1.1-2.2-SNAPSHOT@sha256:a502eedb69405bad165cf5289b89ae169cb494b24630c9d4cbd5400ca1538746
     container_name: authz
     env_file: .env
     networks:

--- a/fcrepo/4.7.5-SNAPSHOT/Dockerfile
+++ b/fcrepo/4.7.5-SNAPSHOT/Dockerfile
@@ -2,7 +2,7 @@ FROM tomcat:8.5.31-jre8-alpine@sha256:f9a53932a3cc61ea3a1c307e7bf60897bce356c60c
 
 ENV FCREPO_VERSION=4.7.5 \
 JSONLD_ADDON_VERSION=0.0.6-SNAPSHOT \
-PASS_AUTHZ_VERSION=0.1.0-SNAPSHOT \
+PASS_AUTHZ_VERSION=0.1.1-SNAPSHOT \
 JMS_ADDON_VERSION=0.0.2 \
 FCREPO_HOME=${CATALINA_HOME}/fcrepo4-data \
 FCREPO_HOST=fcrepo \
@@ -61,11 +61,11 @@ RUN apk update && \
         | sha1sum -c -  && \
     wget -O ${CATALINA_HOME}/lib/pass-authz-filters-shaded.jar \
         https://github.com/OA-PASS/pass-authz/releases/download/${PASS_AUTHZ_VERSION}/pass-authz-filters-${PASS_AUTHZ_VERSION}-shaded.jar && \
-    echo "22c63f5358617d4eb0ab4b629bd21a69b01517c9 *${CATALINA_HOME}/lib/pass-authz-filters-shaded.jar" \
+    echo "2e1e0d4b39b32304a66bccc1a0821d58674a0234 *${CATALINA_HOME}/lib/pass-authz-filters-shaded.jar" \
         | sha1sum -c -  && \
     wget -O ${CATALINA_HOME}/webapps/pass-user-service.war \
         https://github.com/OA-PASS/pass-authz/releases/download/${PASS_AUTHZ_VERSION}/pass-user-service-${PASS_AUTHZ_VERSION}.war && \
-    echo "d49a7cfa94390cff66828ae5f33eecc79642e5cd *${CATALINA_HOME}/webapps/pass-user-service.war" \
+    echo "502bcbff78497f00a93038f3e3596dcf7dd3c010 *${CATALINA_HOME}/webapps/pass-user-service.war" \
         | sha1sum -c -  && \
     mkdir ${CATALINA_HOME}/webapps/pass-user-service && \
     unzip ${CATALINA_HOME}/webapps/pass-user-service.war -d ${CATALINA_HOME}/webapps/pass-user-service  && \


### PR DESCRIPTION
Points to latest authz, static-html, and ember. Changes to fcrepo Docker to point to latest jars/wars.

### fcrepo / authz changes:
Adds a body "Unauthorized" to 401 response. This is a workaround since Ember errors don't appear to receive all error details, but do receive a response body for 401s and can use this to decide what to do with the error.  When this is working, 401s on whoami should return "Unauthorized" as the body text. 
To test: 
1. Open a new incognito browser; log in as `staff2`; visit https://pass/pass-user-service/whoami; see that it says "Unauthorized". 
2. Open a new incognito browser; log in as an authorized user e.g. `nih-user`; visit https://pass/pass-user-service/whoami; see that the user information is there.

### static-html changes:
* adds a red banner to top of page and removes badly positioned footer if you try to go to the site with IE, tells you to use other browsers 
* Format error pages to include icon, simplified text

### ember changes: 
* http encodes file names so high unicode chars don't cause failed file upload
* handles decoded fedora rest paths after /submissions/ or /grants/ (when redirected back from login page, this was getting decoded and causing errors)
* removes some console logs for error handler
* Format error pages to include icon, simplified text
* Redirects errors with payload of "Unauthorized" to 401