### PR TITLE
Update images, includes duplicate user prevention in user service, error handling changes

### DIFF
--- a/.env
+++ b/.env
@@ -7,14 +7,14 @@ STATIC_HTML_PORT=82
 
 # Static html server build-time config
 STATIC_HTML_GIT_REPO=https://github.com/OA-PASS/pass-ui-static.git
-STATIC_HTML_GIT_BRANCH=50b17b97204c8e18e046933824d968cfbb60fb49
+STATIC_HTML_GIT_BRANCH=eb6c317b649b168fc330a50b4053cf1fcab5ad7b
 
 # Ember app runtime config
 EMBER_PORT=81
 
 # Ember app build-time config
 EMBER_GIT_REPO=https://github.com/OA-PASS/pass-ember
-EMBER_GIT_BRANCH=def62bf28ddcb36887982e17663036d5b2364ac2
+EMBER_GIT_BRANCH=f78c434ea7251afd6f61ac49d8b3c2ad0c292fd8
 EMBER_ROOT_URL=/app/
 
 # Fedora config

--- a/authz/Dockerfile
+++ b/authz/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8u151-jre-alpine3.7@sha256:795d1c079217bdcbff740874b78ddea80d5df858b3999951a33871ee61de15ce
 
-ENV VERSION=0.1.1-SNAPSHOT \
+ENV VERSION=0.1.2-SNAPSHOT \
     AUTHZ_MAX_ATTEMPTS=20 \
     PASS_BACKEND_ROLE=http://oapass.org/ns/roles/johnshopkins.edu#pass-backend \
     PASS_GRANTADMIN_ROLE=http://oapass.org/ns/roles/johnshopkins.edu#admin \
@@ -13,7 +13,7 @@ ADD wait_and_start.sh /app
 
 RUN apk add --no-cache ca-certificates wget gettext curl && \
     wget https://github.com/OA-PASS/pass-authz/releases/download/${VERSION}/pass-authz-tools-${VERSION}-listener-exe.jar && \
-    echo "fa40cc62e00ea705862cdaf1a1f0f4ad5c734e04 *pass-authz-tools-${VERSION}-listener-exe.jar" \
+    echo "4d2d96410f336a4f742f4fdd21f19d3082aa3e3a *pass-authz-tools-${VERSION}-listener-exe.jar" \
         | sha1sum -c -  && \
     rm -rf /var/cache/apk/ && \
     chmod 700 wait_and_start.sh 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       args:
         EMBER_GIT_REPO: "${EMBER_GIT_REPO}"
         EMBER_GIT_BRANCH: "${EMBER_GIT_BRANCH}"
-    image: oapass/ember:20180710-def62bf@sha256:d61d5dd96bbe792434a15e5cf7b04ddd8010ed976d97353af0fc3682097dee98
+    image: oapass/ember:20180717-f78c434@sha256:fb9053cbcc7d49b3c334ca5342a24192af5d3c118f56b24bfbe7449730c8b022
     container_name: ember
     env_file: .env
     networks:
@@ -52,7 +52,7 @@ services:
       args:
         STATIC_HTML_GIT_REPO: "${STATIC_HTML_GIT_REPO}"
         STATIC_HTML_GIT_BRANCH: "${STATIC_HTML_GIT_BRANCH}"
-    image: oapass/static-html:20180706-50b17b9@sha256:96361a5ffea55c09a60ad2e27697b8430e76a71e78d43a0c7892bddc29c96772
+    image: oapass/static-html:20180706-eb6c317@sha256:d79a7a468dd4c6f67c0079bd26ac29edbce115ed0d4bb66eb9687f3d42f40968
     container_name: static-html
     env_file: .env
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -203,7 +203,7 @@ services:
 
   authz:
     build: ./authz
-    image: oapass/authz:0.1.1-2.2-SNAPSHOT@sha256:a502eedb69405bad165cf5289b89ae169cb494b24630c9d4cbd5400ca1538746
+    image: oapass/authz:0.1.2-2.2-SNAPSHOT@sha256:024f2c2902f0a8d7191310fafe848f38b09565fa17e8ed22de56866eab5721dc
     container_name: authz
     env_file: .env
     networks:

--- a/fcrepo/4.7.5-SNAPSHOT/Dockerfile
+++ b/fcrepo/4.7.5-SNAPSHOT/Dockerfile
@@ -2,7 +2,7 @@ FROM tomcat:8.5.31-jre8-alpine@sha256:f9a53932a3cc61ea3a1c307e7bf60897bce356c60c
 
 ENV FCREPO_VERSION=4.7.5 \
 JSONLD_ADDON_VERSION=0.0.6-SNAPSHOT \
-PASS_AUTHZ_VERSION=0.1.1-SNAPSHOT \
+PASS_AUTHZ_VERSION=0.1.2-SNAPSHOT \
 JMS_ADDON_VERSION=0.0.2 \
 FCREPO_HOME=${CATALINA_HOME}/fcrepo4-data \
 FCREPO_HOST=fcrepo \
@@ -63,11 +63,11 @@ RUN apk update && \
         | sha1sum -c -  && \
     wget -O ${CATALINA_HOME}/lib/pass-authz-filters-shaded.jar \
         https://github.com/OA-PASS/pass-authz/releases/download/${PASS_AUTHZ_VERSION}/pass-authz-filters-${PASS_AUTHZ_VERSION}-shaded.jar && \
-    echo "2e1e0d4b39b32304a66bccc1a0821d58674a0234 *${CATALINA_HOME}/lib/pass-authz-filters-shaded.jar" \
+    echo "1e8d710a20df5d4c4e168be92faf1b530e2a6e89 *${CATALINA_HOME}/lib/pass-authz-filters-shaded.jar" \
         | sha1sum -c -  && \
     wget -O ${CATALINA_HOME}/webapps/pass-user-service.war \
         https://github.com/OA-PASS/pass-authz/releases/download/${PASS_AUTHZ_VERSION}/pass-user-service-${PASS_AUTHZ_VERSION}.war && \
-    echo "502bcbff78497f00a93038f3e3596dcf7dd3c010 *${CATALINA_HOME}/webapps/pass-user-service.war" \
+    echo "b3e79012a09a97048ded20b76abf3501fa5685df *${CATALINA_HOME}/webapps/pass-user-service.war" \
         | sha1sum -c -  && \
     mkdir ${CATALINA_HOME}/webapps/pass-user-service && \
     unzip ${CATALINA_HOME}/webapps/pass-user-service.war -d ${CATALINA_HOME}/webapps/pass-user-service  && \


### PR DESCRIPTION
Points to latest images and newest pass-authz release. This version includes:
* Faculty with no grants (like `faculty2`) should no longer produce duplicate users, or be locked out for 30 minutes the first time they log in. 
* There is a new FAQ question for "Who can use PASS?"
* Output of full error message in default error message popup

To test double user issue:
1. Get copy of this `pass-docker`
2. Do `docker volume prune` to make sure the database is fresh.
3. Do `docker-compose pull`
4. Do `docker-compose up`
5. Login as `faculty2`, see that there are no problems
6. Check this search only returns one user: http://localhost:9200/_search?q=@type:User+displayName:*Hasnogrants*&default_operator=AND&pretty

To test the double user issue as it will be in production, where authz container isn't running:
1. Modify `docker-compose.yml` to point to this `birkland/assets:2018-06-20@sha256:a0c584ca72683178382fb6002330c034d10b1b91851202fabfaef9fb812b9863`
2. Do `docker volume prune` to make sure the database is fresh.
3. Do `docker-compose pull`
4. Do `docker-compose up assets fcrepo indexer elasticsearch sp ldap idp proxy activemq ember static-
html` (you can start the others too, `dspace` etc, if you want to but don't need to for this - it's most important not to start `authz`)
5. Login as `faculty2`, see that there are no problems.
6. Check this search only returns on user: http://localhost:9200/_search?q=@type:User+displayName:*Hasnogrants*&default_operator=AND&pretty