### PR TITLE
Update to Fedora image to support the 2.3 model.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   fcrepo:
     build:
       context: ./fcrepo/4.7.5-SNAPSHOT
-    image: oapass/fcrepo:4.7.5-2.2-SNAPSHOT-13@sha256:b34b33a52de0eb62ea4295570b40dffe3121758ee2e8b1f9fbac5918035ec5d5
+    image: oapass/fcrepo:4.7.5-2.3-SNAPSHOT@sha256:0ac0d9639af2666747b213c505e48734215d1ee49b1614979980d8870a1d80ed
     container_name: fcrepo
     env_file: .env
     ports:

--- a/fcrepo/4.7.5-SNAPSHOT/Dockerfile
+++ b/fcrepo/4.7.5-SNAPSHOT/Dockerfile
@@ -23,13 +23,15 @@ FCREPO_LOGBACK_LOCATION=webapps/fcrepo/WEB-INF/classes/logback.xml \
 FCREPO_PROPERTIES_MANAGEMENT=relaxed \
 SLF4J_VERSION=1.7.25 \
 DEBUG_ARG="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5006" \
-COMPACTION_URI=https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.2.jsonld \
+COMPACTION_URI=https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.3.jsonld \
 COMPACTION_PRELOAD_URI_PASS_STATIC_2_0=https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.0.jsonld \
 COMPACTION_PRELOAD_FILE_PASS_STATIC_2_0=/usr/local/tomcat/lib/context-2.0.jsonld \
 COMPACTION_PRELOAD_URI_PASS_STATIC_2_1=https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.1.jsonld \
 COMPACTION_PRELOAD_FILE_PASS_STATIC_2_1=/usr/local/tomcat/lib/context-2.1.jsonld \
 COMPACTION_PRELOAD_URI_PASS_STATIC_2_2=https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.2.jsonld \
 COMPACTION_PRELOAD_FILE_PASS_STATIC_2_2=/usr/local/tomcat/lib/context-2.2.jsonld \
+COMPACTION_PRELOAD_URI_PASS_STATIC_2_3=https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.3.jsonld \
+COMPACTION_PRELOAD_FILE_PASS_STATIC_2_3=/usr/local/tomcat/lib/context-2.3.jsonld \
 JSONLD_STRICT=true \
 JSONLD_CONTEXT_PERSIST=true \
 JSONLD_CONTEXT_MINIMAL=true \
@@ -94,6 +96,8 @@ RUN wget -O ${COMPACTION_PRELOAD_FILE_PASS_STATIC_2_0} \
         ${COMPACTION_PRELOAD_URI_PASS_STATIC_2_1} && \
     wget -O ${COMPACTION_PRELOAD_FILE_PASS_STATIC_2_2} \
         ${COMPACTION_PRELOAD_URI_PASS_STATIC_2_2} && \
+    wget -O ${COMPACTION_PRELOAD_FILE_PASS_STATIC_2_3} \
+                ${COMPACTION_PRELOAD_URI_PASS_STATIC_2_3} && \
     rm ${CATALINA_HOME}/webapps/fcrepo/WEB-INF/lib/modeshape-jcr-5.4.0.Final.jar && \
     wget -O ${CATALINA_HOME}/webapps/fcrepo/WEB-INF/lib/modeshape-jcr-5.4.0-maint-01.jar \
         https://github.com/OA-PASS/modeshape/releases/download/modeshape-5.4.0-maint-01/modeshape-jcr-5.4.0.Final.jar && \


### PR DESCRIPTION
Update to Fedora image to support the 2.3 model.
  * Bump and pin oapass/fcrepo:4.7.5-2.3-SNAPSHOT.