### PR TITLE
Use 'pass.local' for local pass address

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ If the images deployed to Docker Hub are up-to-date, then you do not need to bui
 If you built the images (or if you already have the images locally from a previous build), services should begin to start right away.  If you did not build the images, Docker will first pull the images from Docker Hub.
 
 The PASS home page is accessible at `https://pass.local`.  It links to the pass ember app at `https://pass.local/app`.  These are the correct URLs to use
-to use pass as a User.  You'll be prompted to log in as necessary.  Use one of the [Shibboleth users](#shibboleth-users) below to log in.
+You'll be prompted to log in as necessary.  Use one of the [Shibboleth users](#shibboleth-users) below to log in.
 
 
 After starting the demo with the defaults, the following services shoud be accessible directly to developers:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ These instructions are for starting PASS with `docker-compose`.  If you have Doc
 
 <h2><a id="prereq" href="#prereq">Prerequisites</a></h2>
 
-1. Create a "hosts" entry (`lmhosts` for windows, `/etc/hosts` for *nix) that aliases the hostname `pass` to your loopback address (`127.0.0.1`) or to your docker-machine address (e.g. `192.168.99.100`)
+1. Create a "hosts" entry (`C:\Windows\System32\Drivers\etc\hosts` for windows, `/etc/hosts` for *nix) that aliases the hostname `pass.local` to your loopback address (`127.0.0.1`) or to your docker-machine address (e.g. `192.168.99.100`)
 2. A working Docker installation: Docker for Mac, Docker for Windows, Docker Linux, or Docker Machine
 3. Checkout (i.e. clone) this repository: `git clone https://github.com/OA-PASS/pass-demo-docker`
 4. `cd` into `pass-demo-docker`
@@ -112,13 +112,17 @@ If the images deployed to Docker Hub are up-to-date, then you do not need to bui
 
 If you built the images (or if you already have the images locally from a previous build), services should begin to start right away.  If you did not build the images, Docker will first pull the images from Docker Hub.
 
-After starting the demo with the defaults, the following services should work.
+The PASS home page is accessible at `https://pass.local`.  It links to the pass ember app at `https://pass.local/app`.  These are the correct URLs to use
+to use pass as a User.  You'll be prompted to log in as necessary.  Use one of the [Shibboleth users](#shibboleth-users) below to log in.
 
-  - Ember application: [https://localhost](https://localhost). _See [Shibboleth users](#shibboleth-users) below for login options_ 
+
+After starting the demo with the defaults, the following services shoud be accessible directly to developers:
+
+  - Ember application: [https://pass.local/app](https://pass.local/app). _See [Shibboleth users](#shibboleth-users) below for login options_ 
   - Internal FTP server: `localhost:21`, username: `nihmsftpuser` password: `nihmsftppass`
   - HTTP POST submission trigger: `localhost:8081`
   - Fedora: `http://localhost:8080/fcrepo/rest`
-  - Same Fedora instance behind a Shibboleth SP: `https://localhost/fcrepo/rest`
+  - Same Fedora instance behind a Shibboleth SP: `https://pass.local/fcrepo/rest`
   - DSpace repository, exposed at port `8181`: `http://localhost:8181/xmlui`
       - Login with username `dspace-admin@oapass.org`, password `foobar`
       - Not behind the Shibboleth SP

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,7 @@ services:
 
   proxy:
     build: ./httpd-proxy/
-    image: oapass/httpd-proxy:20180622@sha256:423b358d177cb903316b1449ed2d25357137e85a9b3f4d270e30e56354c54c0e
+    image: oapass/httpd-proxy:20180815@sha256:f2aeead1df34ddb8d22b8251a7ef2542f7aedb75952c57a8caecf4c74fd79bb7
     container_name: proxy
     networks:
      - front
@@ -86,7 +86,7 @@ services:
 
   idp:
     build: ./idp/3.3.2
-    image: oapass/idp:20180518@sha256:8fc230e81574161626c8cebd9fda35ae2ff0f8a0c8bce085397972ecb09ce7eb
+    image: oapass/idp:20180815@sha256:8cb8e3ac890200bd1611b1b9c82e3cebf7ace1007e5cdfab36eab3118f70be6b
     container_name: idp
     depends_on:
      - ldap
@@ -114,7 +114,7 @@ services:
 
   sp:
     build: ./sp/2.6.1
-    image: oapass/sp:20180618@sha256:6999dc7a46c3fd3710bb215d562aca12463e8366eead899ec633b84e1456af3a
+    image: oapass/sp:20180815@sha256:2882114242a7f3160605b3e0f0adfc348f5b74fe625e1eae8db1bb034200c2a8
     container_name: sp
     networks:
      - back

--- a/httpd-proxy/etc-httpd/conf.d/httpd.conf
+++ b/httpd-proxy/etc-httpd/conf.d/httpd.conf
@@ -81,7 +81,7 @@ EECDH EDH+aRSA !aNULL !eNULL !LOW !3DES !MD5 !EXP !PSK !SRP !DSS !RC4"
         RequestHeader unset Accept-Encoding
 
         AddOutputFilterByType SUBSTITUTE application/json
-        Substitute "s|http://fcrepo:8080/fcrepo/rest/|https://pass/fcrepo/rest/|n"
+        Substitute "s|http://fcrepo:8080/fcrepo/rest/|https://pass.local/fcrepo/rest/|n"
     </Location>
 
     # Allow DSpace to be addressed through the proxy
@@ -94,7 +94,7 @@ EECDH EDH+aRSA !aNULL !eNULL !LOW !3DES !MD5 !EXP !PSK !SRP !DSS !RC4"
         RequestHeader unset Accept-Encoding
 
         AddOutputFilterByType SUBSTITUTE application/json
-        Substitute "s|http://dspace:8181/xmlui/|https://pass/xmlui/|n"
+        Substitute "s|http://dspace:8181/xmlui/|https://pass.local/xmlui/|n"
     </Location>
 
     # Ember app

--- a/idp/3.3.2/shibboleth-idp/conf/cas-protocol.xml
+++ b/idp/3.3.2/shibboleth-idp/conf/cas-protocol.xml
@@ -28,7 +28,7 @@
                       p:singleLogoutParticipant="true" />
                 -->
                 <bean class="net.shibboleth.idp.cas.service.ServiceDefinition"
-                      c:regex="https://pass/.*"
+                      c:regex="https://pass.local/.*"
                       p:group="non-proxying-services"
                       p:authorizedToProxy="false" />
                 

--- a/idp/3.3.2/shibboleth-idp/conf/idp.properties
+++ b/idp/3.3.2/shibboleth-idp/conf/idp.properties
@@ -2,7 +2,7 @@
 idp.additionalProperties= /conf/ldap.properties, /conf/saml-nameid.properties, /conf/services.properties
 
 # Set the entityID of the IdP
-idp.entityID= https://pass/idp/shibboleth
+idp.entityID= https://pass.local/idp/shibboleth
 
 # Set the scope used in the attribute resolver for scoped attributes
 idp.scope= johnshopkins.edu

--- a/idp/3.3.2/shibboleth-idp/conf/ldap.properties
+++ b/idp/3.3.2/shibboleth-idp/conf/ldap.properties
@@ -7,7 +7,7 @@
 idp.authn.LDAP.ldapURL                          = ldap://ldap:389
 idp.authn.LDAP.useStartTLS                     = false
 idp.authn.LDAP.useSSL                          = false
-#idp.authn.LDAP.connectTimeout                  = 3000
+idp.authn.LDAP.connectTimeout                  = 60000
 
 ## SSL configuration, either jvmTrust, certificateTrust, or keyStoreTrust
 #idp.authn.LDAP.sslConfig                       = certificateTrust

--- a/idp/3.3.2/shibboleth-idp/metadata/idp-metadata.xml
+++ b/idp/3.3.2/shibboleth-idp/metadata/idp-metadata.xml
@@ -5,7 +5,7 @@
 
      This metadata is not dynamic - it will not change as your configuration changes.
 -->
-<EntityDescriptor  xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:shibmd="urn:mace:shibboleth:metadata:1.0" xmlns:xml="http://www.w3.org/XML/1998/namespace" xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui" entityID="https://pass/idp/shibboleth">
+<EntityDescriptor  xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:shibmd="urn:mace:shibboleth:metadata:1.0" xmlns:xml="http://www.w3.org/XML/1998/namespace" xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui" entityID="https://pass.local/idp/shibboleth">
 
     <IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
 
@@ -101,8 +101,8 @@ p+tGUbGS2l873J5PrsbpeKEVR/IIoKo=
 
         </KeyDescriptor>
 
-        <ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://pass:8443/idp/profile/SAML1/SOAP/ArtifactResolution" index="1"/>
-        <ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://pass:8443/idp/profile/SAML2/SOAP/ArtifactResolution" index="2"/>
+        <ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://pass.local:8443/idp/profile/SAML1/SOAP/ArtifactResolution" index="1"/>
+        <ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://pass.local:8443/idp/profile/SAML2/SOAP/ArtifactResolution" index="2"/>
 
         <!--
         <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idptestbed/idp/profile/SAML2/Redirect/SLO"/>
@@ -114,10 +114,10 @@ p+tGUbGS2l873J5PrsbpeKEVR/IIoKo=
         <NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</NameIDFormat>
         <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
 
-        <SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://pass/idp/profile/Shibboleth/SSO"/>
-        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://pass/idp/profile/SAML2/POST/SSO"/>
-        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://pass/idp/profile/SAML2/POST-SimpleSign/SSO"/>
-        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://pass/idp/profile/SAML2/Redirect/SSO"/>
+        <SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://pass.local/idp/profile/Shibboleth/SSO"/>
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://pass.local/idp/profile/SAML2/POST/SSO"/>
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://pass.local/idp/profile/SAML2/POST-SimpleSign/SSO"/>
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://pass.local/idp/profile/SAML2/Redirect/SSO"/>
 
     </IDPSSODescriptor>
 
@@ -207,7 +207,7 @@ p+tGUbGS2l873J5PrsbpeKEVR/IIoKo=
 
         </KeyDescriptor>
 
-        <AttributeService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://pass:8443/idp/profile/SAML1/SOAP/AttributeQuery"/>
+        <AttributeService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://pass.local:8443/idp/profile/SAML1/SOAP/AttributeQuery"/>
         <!-- <AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://idptestbed:8443/idp/profile/SAML2/SOAP/AttributeQuery"/> -->
         <!-- If you uncomment the above you should add urn:oasis:names:tc:SAML:2.0:protocol to the protocolSupportEnumeration above -->
 

--- a/idp/3.3.2/shibboleth-idp/metadata/sp-metadata.xml
+++ b/idp/3.3.2/shibboleth-idp/metadata/sp-metadata.xml
@@ -26,7 +26,7 @@ and do *NOT* provide it in real time to your partners.
 
   <md:SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:oasis:names:tc:SAML:1.0:protocol">
     <md:Extensions>
-      <init:RequestInitiator xmlns:init="urn:oasis:names:tc:SAML:profiles:SSO:request-init" Binding="urn:oasis:names:tc:SAML:profiles:SSO:request-init" Location="https://pass/Shibboleth.sso/Login"/>
+      <init:RequestInitiator xmlns:init="urn:oasis:names:tc:SAML:profiles:SSO:request-init" Binding="urn:oasis:names:tc:SAML:profiles:SSO:request-init" Location="https://pass.local/Shibboleth.sso/Login"/>
     </md:Extensions>
     <md:KeyDescriptor>
       <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
@@ -62,17 +62,17 @@ lQQUhxyEXTBJx3luLlpIjoloFKIute9K7pE5qAENjg==
       <md:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#rsa-oaep"/>
       <md:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p"/>
     </md:KeyDescriptor>
-    <md:ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://pass/Shibboleth.sso/Artifact/SOAP" index="1"/>
-    <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://pass/Shibboleth.sso/SLO/SOAP"/>
-    <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://pass/Shibboleth.sso/SLO/Redirect"/>
-    <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://pass/Shibboleth.sso/SLO/POST"/>
-    <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://pass/Shibboleth.sso/SLO/Artifact"/>
-    <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://pass/Shibboleth.sso/SAML2/POST" index="1"/>
-    <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://pass/Shibboleth.sso/SAML2/POST-SimpleSign" index="2"/>
-    <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://pass/Shibboleth.sso/SAML2/Artifact" index="3"/>
-    <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:PAOS" Location="https://pass/Shibboleth.sso/SAML2/ECP" index="4"/>
-    <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:1.0:profiles:browser-post" Location="https://pass/Shibboleth.sso/SAML/POST" index="5"/>
-    <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:1.0:profiles:artifact-01" Location="https://pass/Shibboleth.sso/SAML/Artifact" index="6"/>
+    <md:ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://pass.local/Shibboleth.sso/Artifact/SOAP" index="1"/>
+    <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://pass.local/Shibboleth.sso/SLO/SOAP"/>
+    <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://pass.local/Shibboleth.sso/SLO/Redirect"/>
+    <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://pass.local/Shibboleth.sso/SLO/POST"/>
+    <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://pass.local/Shibboleth.sso/SLO/Artifact"/>
+    <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://pass.local/Shibboleth.sso/SAML2/POST" index="1"/>
+    <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://pass.local/Shibboleth.sso/SAML2/POST-SimpleSign" index="2"/>
+    <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://pass.local/Shibboleth.sso/SAML2/Artifact" index="3"/>
+    <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:PAOS" Location="https://pass.local/Shibboleth.sso/SAML2/ECP" index="4"/>
+    <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:1.0:profiles:browser-post" Location="https://pass.local/Shibboleth.sso/SAML/POST" index="5"/>
+    <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:1.0:profiles:artifact-01" Location="https://pass.local/Shibboleth.sso/SAML/Artifact" index="6"/>
   </md:SPSSODescriptor>
 
 </md:EntityDescriptor>

--- a/sp/2.6.1/etc-httpd/conf.d/sp.conf
+++ b/sp/2.6.1/etc-httpd/conf.d/sp.conf
@@ -4,7 +4,7 @@ AllowEncodedSlashes NoDecode
 
 <VirtualHost *:80>
 
-    ServerName https://pass:443
+    ServerName https://pass.local:443
     UseCanonicalName On
 
     LogLevel debug

--- a/sp/2.6.1/etc-shibboleth/idp-metadata.xml
+++ b/sp/2.6.1/etc-shibboleth/idp-metadata.xml
@@ -5,7 +5,7 @@
 
      This metadata is not dynamic - it will not change as your configuration changes.
 -->
-<EntityDescriptor  xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:shibmd="urn:mace:shibboleth:metadata:1.0" xmlns:xml="http://www.w3.org/XML/1998/namespace" xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui" entityID="https://pass/idp/shibboleth">
+<EntityDescriptor  xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:shibmd="urn:mace:shibboleth:metadata:1.0" xmlns:xml="http://www.w3.org/XML/1998/namespace" xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui" entityID="https://pass.local/idp/shibboleth">
 
     <IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
 
@@ -101,8 +101,8 @@ p+tGUbGS2l873J5PrsbpeKEVR/IIoKo=
 
         </KeyDescriptor>
 
-        <ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://pass:8443/idp/profile/SAML1/SOAP/ArtifactResolution" index="1"/>
-        <ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://pass:8443/idp/profile/SAML2/SOAP/ArtifactResolution" index="2"/>
+        <ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://pass.local:8443/idp/profile/SAML1/SOAP/ArtifactResolution" index="1"/>
+        <ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://pass.local:8443/idp/profile/SAML2/SOAP/ArtifactResolution" index="2"/>
 
         <!--
         <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idptestbed/idp/profile/SAML2/Redirect/SLO"/>
@@ -114,10 +114,10 @@ p+tGUbGS2l873J5PrsbpeKEVR/IIoKo=
         <NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</NameIDFormat>
         <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
 
-        <SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://pass/idp/profile/Shibboleth/SSO"/>
-        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://pass/idp/profile/SAML2/POST/SSO"/>
-        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://pass/idp/profile/SAML2/POST-SimpleSign/SSO"/>
-        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://pass/idp/profile/SAML2/Redirect/SSO"/>
+        <SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://pass.local/idp/profile/Shibboleth/SSO"/>
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://pass.local/idp/profile/SAML2/POST/SSO"/>
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://pass.local/idp/profile/SAML2/POST-SimpleSign/SSO"/>
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://pass.local/idp/profile/SAML2/Redirect/SSO"/>
 
     </IDPSSODescriptor>
 
@@ -207,7 +207,7 @@ p+tGUbGS2l873J5PrsbpeKEVR/IIoKo=
 
         </KeyDescriptor>
 
-        <AttributeService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://pass:8443/idp/profile/SAML1/SOAP/AttributeQuery"/>
+        <AttributeService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://pass.local:8443/idp/profile/SAML1/SOAP/AttributeQuery"/>
         <!-- <AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://idptestbed:8443/idp/profile/SAML2/SOAP/AttributeQuery"/> -->
         <!-- If you uncomment the above you should add urn:oasis:names:tc:SAML:2.0:protocol to the protocolSupportEnumeration above -->
 

--- a/sp/2.6.1/etc-shibboleth/shibboleth2.xml
+++ b/sp/2.6.1/etc-shibboleth/shibboleth2.xml
@@ -43,7 +43,7 @@
             (Set discoveryProtocol to "WAYF" for legacy Shibboleth WAYF support.)
             You can also override entityID on /Login query string, or in RequestMap/htaccess.
             -->
-            <SSO entityID="https://pass/idp/shibboleth">
+            <SSO entityID="https://pass.local/idp/shibboleth">
               SAML2 SAML1
             </SSO>
 


### PR DESCRIPTION
## Overview
Changes `pass-docker` such that the public (proxied) address for pass is `https://pass.local`, rather than `https://pass`.  

Resolves #25 incidentally, by increasing the length of a connection timeout to ldap

## To Test
* Edit your hosts file (`/etc/hosts` or `C:\Windows\System32\Drivers\etc\hosts`) to add entry<pre>127.0.0.1               pass.local</pre>
  * It might be a good idea to remove the entry for `pass`, since it is going away.
* Do a `docker-compose pull`
* Go to `https://pass.local` and verify that the static pages work
* Click on the login link or go to `https://pass.local/app` and log in as your favorite shib user (e.g. `nih-user`).  Verify that the PASS app still appears to work

## Interested Parties
@karenhanson 