### PR TITLE
Use the latest pass-authz in fcrepo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   fcrepo:
     build:
       context: ./fcrepo/4.7.5-SNAPSHOT
-    image: oapass/fcrepo:4.7.5-2.3-SNAPSHOT@sha256:0ac0d9639af2666747b213c505e48734215d1ee49b1614979980d8870a1d80ed
+    image: oapass/fcrepo:4.7.5-2.3-SNAPSHOT-1@sha256:37bc1cbcb4513d0024db65f628bef25c7cd8024be13e50b41fc6864b783c396b
     container_name: fcrepo
     env_file: .env
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   fcrepo:
     build:
       context: ./fcrepo/4.7.5-SNAPSHOT
-    image: oapass/fcrepo:4.7.5-2.3-SNAPSHOT-1@sha256:37bc1cbcb4513d0024db65f628bef25c7cd8024be13e50b41fc6864b783c396b
+    image: oapass/fcrepo:4.7.5-2.3-SNAPSHOT-1@sha256:a03008e5c4517a6256712963df47b9bf3540318fb95ca26731775c6c26f22105
     container_name: fcrepo
     env_file: .env
     ports:

--- a/fcrepo/4.7.5-SNAPSHOT/Dockerfile
+++ b/fcrepo/4.7.5-SNAPSHOT/Dockerfile
@@ -2,7 +2,7 @@ FROM tomcat:8.5.31-jre8-alpine@sha256:f9a53932a3cc61ea3a1c307e7bf60897bce356c60c
 
 ENV FCREPO_VERSION=4.7.5 \
 JSONLD_ADDON_VERSION=0.0.6-SNAPSHOT \
-PASS_AUTHZ_VERSION=0.2.0-SNAPSHOT \
+PASS_AUTHZ_VERSION=0.2.1-SNAPSHOT \
 JMS_ADDON_VERSION=0.0.2 \
 FCREPO_HOME=${CATALINA_HOME}/fcrepo4-data \
 FCREPO_HOST=fcrepo \
@@ -63,15 +63,15 @@ RUN apk update && \
         | sha1sum -c -  && \
     wget -O ${CATALINA_HOME}/lib/pass-authz-core-${PASS_AUTHZ_VERSION}-shaded.jar \
         https://github.com/OA-PASS/pass-authz/releases/download/${PASS_AUTHZ_VERSION}/pass-authz-core-${PASS_AUTHZ_VERSION}-shaded.jar && \
-    echo "43c3370828ec2eb3f32773cc34ef236b133d53c5 *${CATALINA_HOME}/lib/pass-authz-core-${PASS_AUTHZ_VERSION}-shaded.jar" \
+    echo "ea729bb05c965e581f5489e250c0e2dc2232c05d *${CATALINA_HOME}/lib/pass-authz-core-${PASS_AUTHZ_VERSION}-shaded.jar" \
        | sha1sum -c -  && \
     wget -O ${CATALINA_HOME}/lib/pass-authz-roles-${PASS_AUTHZ_VERSION}.jar \
         https://github.com/OA-PASS/pass-authz/releases/download/${PASS_AUTHZ_VERSION}/pass-authz-roles-${PASS_AUTHZ_VERSION}.jar && \
-    echo "a2dd8ee4c7b0a2306881f42ed9844c5bce55dbfb *${CATALINA_HOME}/lib/pass-authz-roles-${PASS_AUTHZ_VERSION}.jar" \
+    echo "42262b92902988ac6c1bbf0a33ddd968c2a5913c *${CATALINA_HOME}/lib/pass-authz-roles-${PASS_AUTHZ_VERSION}.jar" \
         | sha1sum -c -  && \
     wget -O ${CATALINA_HOME}/webapps/pass-user-service.war \
         https://github.com/OA-PASS/pass-authz/releases/download/${PASS_AUTHZ_VERSION}/pass-user-service-${PASS_AUTHZ_VERSION}.war && \
-    echo "0a5abf8d5a6b558a0c6f8e4d07bc0f14d8604dfd *${CATALINA_HOME}/webapps/pass-user-service.war" \
+    echo "7b556897692e09ef744cce12d7c085bfc05926e7 *${CATALINA_HOME}/webapps/pass-user-service.war" \
         | sha1sum -c -  && \
     mkdir ${CATALINA_HOME}/webapps/pass-user-service && \
     unzip ${CATALINA_HOME}/webapps/pass-user-service.war -d ${CATALINA_HOME}/webapps/pass-user-service  && \

--- a/fcrepo/4.7.5-SNAPSHOT/Dockerfile
+++ b/fcrepo/4.7.5-SNAPSHOT/Dockerfile
@@ -2,7 +2,7 @@ FROM tomcat:8.5.31-jre8-alpine@sha256:f9a53932a3cc61ea3a1c307e7bf60897bce356c60c
 
 ENV FCREPO_VERSION=4.7.5 \
 JSONLD_ADDON_VERSION=0.0.6-SNAPSHOT \
-PASS_AUTHZ_VERSION=0.1.2-SNAPSHOT \
+PASS_AUTHZ_VERSION=0.2.0-SNAPSHOT \
 JMS_ADDON_VERSION=0.0.2 \
 FCREPO_HOME=${CATALINA_HOME}/fcrepo4-data \
 FCREPO_HOST=fcrepo \
@@ -42,7 +42,7 @@ EXPOSE ${FCREPO_PORT}
 VOLUME /data
 
 COPY bin/* /bin/
-COPY conf/* ${CATALINA_HOME}/conf/
+COPY conf/ ${CATALINA_HOME}/conf
 COPY lib/* ${CATALINA_HOME}/lib/
 COPY tomcat-bin/* ${CATALINA_HOME}/bin/
 
@@ -61,13 +61,17 @@ RUN apk update && \
         https://github.com/DataConservancy/fcrepo-jsonld/releases/download/${JSONLD_ADDON_VERSION}/jsonld-addon-filters-${JSONLD_ADDON_VERSION}-shaded.jar && \
     echo "fa95adf77b0933f163e213f8133e8d78df7a9141 *${CATALINA_HOME}/lib/jsonld-addon-filters-${JSONLD_ADDON_VERSION}-shaded.jar" \
         | sha1sum -c -  && \
-    wget -O ${CATALINA_HOME}/lib/pass-authz-filters-shaded.jar \
-        https://github.com/OA-PASS/pass-authz/releases/download/${PASS_AUTHZ_VERSION}/pass-authz-filters-${PASS_AUTHZ_VERSION}-shaded.jar && \
-    echo "1e8d710a20df5d4c4e168be92faf1b530e2a6e89 *${CATALINA_HOME}/lib/pass-authz-filters-shaded.jar" \
+    wget -O ${CATALINA_HOME}/lib/pass-authz-core-${PASS_AUTHZ_VERSION}-shaded.jar \
+        https://github.com/OA-PASS/pass-authz/releases/download/${PASS_AUTHZ_VERSION}/pass-authz-core-${PASS_AUTHZ_VERSION}-shaded.jar && \
+    echo "43c3370828ec2eb3f32773cc34ef236b133d53c5 *${CATALINA_HOME}/lib/pass-authz-core-${PASS_AUTHZ_VERSION}-shaded.jar" \
+       | sha1sum -c -  && \
+    wget -O ${CATALINA_HOME}/lib/pass-authz-roles-${PASS_AUTHZ_VERSION}.jar \
+        https://github.com/OA-PASS/pass-authz/releases/download/${PASS_AUTHZ_VERSION}/pass-authz-roles-${PASS_AUTHZ_VERSION}.jar && \
+    echo "a2dd8ee4c7b0a2306881f42ed9844c5bce55dbfb *${CATALINA_HOME}/lib/pass-authz-roles-${PASS_AUTHZ_VERSION}.jar" \
         | sha1sum -c -  && \
     wget -O ${CATALINA_HOME}/webapps/pass-user-service.war \
         https://github.com/OA-PASS/pass-authz/releases/download/${PASS_AUTHZ_VERSION}/pass-user-service-${PASS_AUTHZ_VERSION}.war && \
-    echo "b3e79012a09a97048ded20b76abf3501fa5685df *${CATALINA_HOME}/webapps/pass-user-service.war" \
+    echo "0a5abf8d5a6b558a0c6f8e4d07bc0f14d8604dfd *${CATALINA_HOME}/webapps/pass-user-service.war" \
         | sha1sum -c -  && \
     mkdir ${CATALINA_HOME}/webapps/pass-user-service && \
     unzip ${CATALINA_HOME}/webapps/pass-user-service.war -d ${CATALINA_HOME}/webapps/pass-user-service  && \

--- a/fcrepo/4.7.5-SNAPSHOT/conf/Catalina/localhost/fcrepo.xml
+++ b/fcrepo/4.7.5-SNAPSHOT/conf/Catalina/localhost/fcrepo.xml
@@ -1,0 +1,1 @@
+<Context crossContext="true"></Context>

--- a/fcrepo/4.7.5-SNAPSHOT/conf/web.xml
+++ b/fcrepo/4.7.5-SNAPSHOT/conf/web.xml
@@ -4722,7 +4722,7 @@
 
     <filter>
       <filter-name>pass-authz-filter</filter-name>
-      <filter-class>org.dataconservancy.pass.authz.filter.PassRolesFilter</filter-class>
+      <filter-class>org.dataconservancy.pass.authz.roles.PassRolesFilter</filter-class>
       <async-supported>true</async-supported>
     </filter>
     


### PR DESCRIPTION
# Overview
Contains various fixes for pass-authz related to removing the vulnerability to elasticsearch time when creating new users.  

# To test
1. Check out the PR, then do a `docker-compose pull`, and a `docker-compose up`
2. log in as `faculty2`.  This is a new user.  previously, I hadn't been able to successfully log in before being denied due to failure to update the index in time.  Make sure you can get in.
3. In a different browser (or incognito mode), log in as another user, make sure that continues to work.

Resolves #113 