### PR TITLE
Update authz image, and assets

### DIFF
--- a/authz/Dockerfile
+++ b/authz/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8u151-jre-alpine3.7@sha256:795d1c079217bdcbff740874b78ddea80d5df858b3999951a33871ee61de15ce
 
-ENV VERSION=0.1.2-SNAPSHOT \
+ENV VERSION=0.2.1-SNAPSHOT \
     AUTHZ_MAX_ATTEMPTS=20 \
     PASS_BACKEND_ROLE=http://oapass.org/ns/roles/johnshopkins.edu#pass-backend \
     PASS_GRANTADMIN_ROLE=http://oapass.org/ns/roles/johnshopkins.edu#admin \
@@ -12,10 +12,10 @@ WORKDIR /app
 ADD wait_and_start.sh /app
 
 RUN apk add --no-cache ca-certificates wget gettext curl && \
-    wget https://github.com/OA-PASS/pass-authz/releases/download/${VERSION}/pass-authz-tools-${VERSION}-listener-exe.jar && \
-    echo "4d2d96410f336a4f742f4fdd21f19d3082aa3e3a *pass-authz-tools-${VERSION}-listener-exe.jar" \
+    wget https://github.com/OA-PASS/pass-authz/releases/download/${VERSION}/pass-authz-listener-${VERSION}-exe.jar && \
+    echo "fd62ede89a84e4b7f8f8e2a6e57ee2684255299b *pass-authz-listener-${VERSION}-exe.jar" \
         | sha1sum -c -  && \
     rm -rf /var/cache/apk/ && \
     chmod 700 wait_and_start.sh 
 
-CMD ./wait_and_start.sh pass-authz-tools-${VERSION}-listener-exe.jar
+CMD ./wait_and_start.sh pass-authz-listener-${VERSION}-exe.jar

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -174,7 +174,7 @@ services:
       - assets
 
   assets:
-    image: birkland/assets:2018-07-06@sha256:2af6f8394e337e31abcf7594c66d03547824a49538aafa6ee688bb4011e8aab5
+    image: birkland/assets:2018-08-01@sha256:5a4e2605f6d37cd12d3a6fbc9afecc16ab427a395b3150b9f072d4b25a06fab2
     build: ./assets
     volumes:
       - passdata:/data
@@ -203,7 +203,7 @@ services:
 
   authz:
     build: ./authz
-    image: oapass/authz:0.1.2-2.2-SNAPSHOT@sha256:024f2c2902f0a8d7191310fafe848f38b09565fa17e8ed22de56866eab5721dc
+    image: oapass/authz:0.2.1-2.3-SNAPSHOT@sha256:b8eca98c4cece4b0eb6df7024eb6bdebff8bc311942f098813cc077d025f08d3
     container_name: authz
     env_file: .env
     networks:


### PR DESCRIPTION
The last authz PR neglected to update the listener component, this PR updates it to `2.1-SNAPSHOT`.  It also neglected to update the assets image.  The assets image in this PR is bumped to the 8/1 version, which removes the individual ACLs that made grants readable only to PIs and CO-PIs (i.e. it makes grants entirely open).