### PR TITLE
[WIP]Update birkland/assets version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -174,7 +174,7 @@ services:
       - assets
 
   assets:
-    image: birkland/assets:2018-09-18@sha256:ac73a08576a02e377c8341bb26237f92148d278da914b507ec0b3e3116ae3140
+    image: birkland/assets:2018-10-01_3.1@sha256:bc29c9569512be1c0759ee7adc1cc02d4c74de1c9b242ac946bb7d32fdaa2aa8
     build: ./assets
     volumes:
       - passdata:/data


### PR DESCRIPTION
Points to latest `birkland/assets` image. This contains the following changes:
* Updates the Elasticsearch mappings internal to `birkland/assets` to reflect the new model fields. 
* The data is migrated to the new model for Submissions (replace `user` with `submitter`, add `preparers` and `submissionStatus`) and Repository (remove agreement text from `formSchema` and add it as separate field).  Does not include changes to `User` data yet.

Warning: this WILL break `pass-ember` in `pass-docker` until the updated version of the Ember application supporting the new model is available.