### PR TITLE
Model 3.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -174,7 +174,7 @@ services:
       - assets
 
   assets:
-    image: birkland/assets:2018-10_09_3.1@sha256:f92c20a84e4c98466c9950fa719d8397db892e0d473cfdd04569aa7861f7e823
+    image: birkland/assets:2018-10-09_3.1@sha256:e9d40e67d0ea784e4812e94ca93b0353c1466cdbd21546906ab14d98f2565001
     build: ./assets
     volumes:
       - passdata:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -174,7 +174,7 @@ services:
       - assets
 
   assets:
-    image: birkland/assets:2018-09-18@sha256:ac73a08576a02e377c8341bb26237f92148d278da914b507ec0b3e3116ae3140
+    image: birkland/assets:2018-10_09_3.1@sha256:f92c20a84e4c98466c9950fa719d8397db892e0d473cfdd04569aa7861f7e823
     build: ./assets
     volumes:
       - passdata:/data


### PR DESCRIPTION
followed the instructions to migrate data - the update was done using two processes. first, karen's migration tool which updates submissions, repository, users, funders and grants. the major update to users is the replacement of institutionalId and employeeId by a list of localized ids, as well as calculate a displayName from firstName, lastName. the second process is to use the COEUS loader to update existing Fedora users in COEUS to include JHED ID and Hopkins ID when available as a localized locatorId and email address.

Resolves https://github.com/OA-PASS/general-issues/issues/35