### PR TITLE
Log environment variables for indexer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,7 +145,7 @@ services:
 
   indexer:
     build: ./indexer/0.0.15-SNAPSHOT
-    image: oapass/indexer:0.0.15-3.1-SNAPSHOT@sha256:17136594594a8816070cdb2068d3e24d3def389fa90b8729cd768124f3a9b8e9
+    image: oapass/indexer:0.0.15-3.1-SNAPSHOT@sha256:69a261ca4e55cf81da2823125f8b2ad6716780f0c6087c13b659bd42d32d018a
     container_name: indexer
     env_file: .env
     networks:

--- a/indexer/0.0.15-SNAPSHOT/wait_and_start.sh
+++ b/indexer/0.0.15-SNAPSHOT/wait_and_start.sh
@@ -71,7 +71,13 @@ function wait_until_es_up {
     echo "Elasticsearch is up"
 }
 
+printf "\n**** Begin Environment Variable Dump ****\n\n"
+printenv | sort
+printf "\n**** End Environment Variable Dump ****\n\n"
+
 wait_until_fedora_up
 wait_until_es_up
+
+echo "executing java -Dorg.slf4j.simpleLogger.defaultLogLevel=${PI_LOG_LEVEL} -jar ${1}"
 
 exec java -Dorg.slf4j.simpleLogger.defaultLogLevel=${PI_LOG_LEVEL} -jar "$1"


### PR DESCRIPTION
To test:

* do a `docker-compose pull`
* `docker-compose up`
* look at the indexer logs `docker logs -f indexer`.  Once the container is started, it'll immediately dump all environment variables.  