### PR TITLE
Push and pin the latest Fedora (3.2 model compatible) image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   fcrepo:
     build:
       context: ./fcrepo/4.7.5
-    image: oapass/fcrepo:4.7.5-3.2@sha256:bb5e0eab6486c6ce0c4896c5903f0231444a131230fc8a847c6059adc29fbdbc
+    image: oapass/fcrepo:4.7.5-3.2-1@sha256:51df2f614da4a88d297dff3f4e7062cba7090cc029c335ba10fed4cedb39a9f7
     container_name: fcrepo
     env_file: .env
     ports:


### PR DESCRIPTION
The previous commit (e2b4d52) was missing a Fedora image that is necessary for notification services.  e2b4d52 included a new queue for Fedora named `event`, but a new image was not built or pushed with e2b4d52.  This PR includes the missing image.