### PR TITLE
Bump authz to 0.4.0

### DIFF
--- a/authz/Dockerfile
+++ b/authz/Dockerfile
@@ -1,5 +1,5 @@
 FROM openjdk:8u171-jre-alpine3.8@sha256:e3168174d367db9928bb70e33b4750457092e61815d577e368f53efb29fea48b
-ENV VERSION=0.3.1 \
+ENV VERSION=0.4.0 \
     AUTHZ_MAX_ATTEMPTS=20 \
     PASS_BACKEND_ROLE=http://oapass.org/ns/roles/johnshopkins.edu#pass-backend \
     PASS_GRANTADMIN_ROLE=http://oapass.org/ns/roles/johnshopkins.edu#admin \
@@ -12,7 +12,7 @@ ADD wait_and_start.sh /app
 
 RUN apk add --no-cache ca-certificates wget gettext curl && \
     wget http://central.maven.org/maven2/org/dataconservancy/pass/pass-authz-listener/${VERSION}/pass-authz-listener-${VERSION}-exe.jar && \
-    echo "8d3efa9b68548f2c2d74cbe401bacd5c3bd7dba0 *pass-authz-listener-${VERSION}-exe.jar" \
+    echo "00bc26f673a6033ac0ad4ba5aaac793b75e2208b *pass-authz-listener-${VERSION}-exe.jar" \
         | sha1sum -c -  && \
     rm -rf /var/cache/apk/ && \
     chmod 700 wait_and_start.sh 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   fcrepo:
     build:
       context: ./fcrepo/4.7.5
-    image: oapass/fcrepo:4.7.5-3.2-1@sha256:51df2f614da4a88d297dff3f4e7062cba7090cc029c335ba10fed4cedb39a9f7
+    image: oapass/fcrepo:4.7.5-3.2-2@sha256:d06ff883b93da52e784e40315cb7f9f10fa38a0d529e83d89a0a120086bf18d8
     container_name: fcrepo
     env_file: .env
     ports:
@@ -203,7 +203,7 @@ services:
 
   authz:
     build: ./authz
-    image: oapass/authz:0.3.1-3.1@sha256:e965e2f55b56d5865a8a3edaf34dc181a7024e9537de9c284bece30f60991a90
+    image: oapass/authz:0.4.0-3.2@sha256:64a5a8e7a4280d990d91ca60dffefbde4ad967547569d13d71e6e0d1aed32492
     container_name: authz
     env_file: .env
     networks:

--- a/fcrepo/4.7.5/Dockerfile
+++ b/fcrepo/4.7.5/Dockerfile
@@ -2,7 +2,7 @@ FROM tomcat:8.5.34-jre8-alpine@sha256:fa2bce34c65dc57162d4764f1a3ce7c734c926616b
 
 ENV FCREPO_VERSION=4.7.5 \
 JSONLD_ADDON_VERSION=0.0.6 \
-PASS_AUTHZ_VERSION=0.3.1 \
+PASS_AUTHZ_VERSION=0.4.0 \
 JMS_ADDON_VERSION=0.0.2 \
 FCREPO_HOME=${CATALINA_HOME}/fcrepo4-data \
 FCREPO_HOST=fcrepo \
@@ -69,15 +69,15 @@ RUN apk update && \
         | sha1sum -c -  && \
     wget -O ${CATALINA_HOME}/lib/pass-authz-core-${PASS_AUTHZ_VERSION}-shaded.jar \
         http://central.maven.org/maven2/org/dataconservancy/pass/pass-authz-core/${PASS_AUTHZ_VERSION}/pass-authz-core-${PASS_AUTHZ_VERSION}-shaded.jar && \
-    echo "6825664d81d98e1ab4bfbff70f3541becdc97e39 *${CATALINA_HOME}/lib/pass-authz-core-${PASS_AUTHZ_VERSION}-shaded.jar" \
+    echo "265c733b0157e5206d7c721603e28283bb622aee *${CATALINA_HOME}/lib/pass-authz-core-${PASS_AUTHZ_VERSION}-shaded.jar" \
        | sha1sum -c -  && \
     wget -O ${CATALINA_HOME}/lib/pass-authz-roles-${PASS_AUTHZ_VERSION}.jar \
         http://central.maven.org/maven2/org/dataconservancy/pass/pass-authz-roles/${PASS_AUTHZ_VERSION}/pass-authz-roles-${PASS_AUTHZ_VERSION}.jar && \
-    echo "f0ee6585012b58394938bfe89609aee006ccd4b9 *${CATALINA_HOME}/lib/pass-authz-roles-${PASS_AUTHZ_VERSION}.jar" \
+    echo "7e3a7e456524c47f4f730d57c0dfb2fd1e81a096 *${CATALINA_HOME}/lib/pass-authz-roles-${PASS_AUTHZ_VERSION}.jar" \
         | sha1sum -c -  && \
     wget -O ${CATALINA_HOME}/webapps/pass-user-service.war \
         http://central.maven.org/maven2/org/dataconservancy/pass/pass-user-service/${PASS_AUTHZ_VERSION}/pass-user-service-${PASS_AUTHZ_VERSION}.war && \
-    echo "306ce9d3735b52e1745cdc7b06b84380f73854d4 *${CATALINA_HOME}/webapps/pass-user-service.war" \
+    echo "12f2b1052e966bad1e699772a5fb436bc61aabe1 *${CATALINA_HOME}/webapps/pass-user-service.war" \
         | sha1sum -c -  && \
     mkdir ${CATALINA_HOME}/webapps/pass-user-service && \
     unzip ${CATALINA_HOME}/webapps/pass-user-service.war -d ${CATALINA_HOME}/webapps/pass-user-service  && \


### PR DESCRIPTION
Uses model 3.2, with the new method of using submitterName and
submitterEmail to convey identity.

## To test
* Just verify that there are no regressions.  The primary change involves inviting new users as part of the proxy use case, but this is not easily verifiable in pass-docker  without an Ember or notification services.  