### PR TITLE
Whitelist all email addresses in LDAP so they can receive notifications

### DIFF
--- a/notification-services/0.0.1-3.2/notification.json
+++ b/notification-services/0.0.1-3.2/notification.json
@@ -8,6 +8,15 @@
         "${pass.notification.demo.global.cc.address}"
       ],
       "whitelist": [
+        "mailto:superuser@jhu.edu",
+        "mailto:grant-admin-submitter@jhu.edu",
+        "mailto:grant-admin@jhu.edu",
+        "mailto:usaiduser@jhu.edu",
+        "mailto:incompletenihuser@jhu.edu",
+        "mailto:eduser@jhu.edu",
+        "mailto:nihuser@jhu.edu",
+        "mailto:facultyWithNoGrants@jhu.edu",
+        "mailto:facultyWithGrants@jhu.edu",
         "mailto:staffWithGrants@jhu.edu",
         "mailto:staffWithNoGrants@jhu.edu"
       ]


### PR DESCRIPTION
Add all email addresses in LDAP to the Notification Services DEMO whitelist.  Note that the carbon copy addresses like notification-demo-cc@jhu.edu do not need to be present on the whitelist- they are implicitly whitelisted when configured as a 'global_cc' address.