### PR TITLE
Re-add `link` to dspace for the deposit container.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -200,6 +200,8 @@ services:
 # To override packager configuration, create a file named './packagers.properties', edit to suit, and uncomment below
 #    volumes:
 #      - ./packagers.properties:/packagers.properties
+    links:
+      - dspace:pass.local
 
   authz:
     build: ./authz


### PR DESCRIPTION
Add link so that the deposit container can address the dspace container as pass.local