### PR TITLE
Migrate repositories and use repositoryKey in DS config

### DIFF
--- a/deposit-services/0.1.0-3.2/repositories.json
+++ b/deposit-services/0.1.0-3.2/repositories.json
@@ -1,5 +1,5 @@
 {
-  "fcrepo/rest/repositories/41/96/0a/92/41960a92-d3f8-4616-86a6-9e9cadc1a269": {
+  "jscholarship": {
     "deposit-config": {
       "processing": {
         "beanName": "org.dataconservancy.pass.deposit.messaging.status.DefaultDepositStatusProcessor"
@@ -36,7 +36,7 @@
       }
     }
   },
-  "fcrepo/rest/repositories/77/64/12/ec/776412ec-0f5e-488e-97dc-15bb427d27e2": {
+  "pmc": {
     "deposit-config": {
       "processing": {
       },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -174,7 +174,7 @@ services:
       - assets
 
   assets:
-    image: birkland/assets:2018-11-07_3.2@sha256:5043faf1e43505e45c013e8f0542b7494ddd6379bcf3714607a42f48bd1f4f3e
+    image: birkland/assets:2018-11-13_3.2@sha256:60310d68c7ab910096f471bf6636b35487c52ab6db970fc280959f49eec0f465
     build: ./assets
     volumes:
       - passdata:/data
@@ -188,7 +188,7 @@ services:
 
   deposit:
     build: ./deposit-services/0.1.0-3.2
-    image: oapass/deposit-services:0.1.0-3.2@sha256:68bce9938c4999ed3d045576e9c0ef3f65b730ec745d24db89400e3aa31484b1
+    image: oapass/deposit-services:0.1.0-3.2-1@sha256:fbe0f70af890ab97a0b2ab6c8d3ad058f7117d81c029b0a1980d037e9a7adc33
     container_name: deposit
     env_file: .env
     environment:


### PR DESCRIPTION
* Uses the repository migrator to update repository text and add
repositoryKeys, producing a new assets version
* Updates deposit services config to use repositoryKey for lookup,
rather than resource path

To test:  Create a submission that deposits to PMC and J10P.  Verify that it still is deposited to both places.