### PR TITLE
Enhance Tomcat logging

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   fcrepo:
     build:
       context: ./fcrepo/4.7.5
-    image: oapass/fcrepo:4.7.5-3.2-2@sha256:d06ff883b93da52e784e40315cb7f9f10fa38a0d529e83d89a0a120086bf18d8
+    image: oapass/fcrepo:4.7.5-3.2-3@sha256:b7036b1f61d84341aea1b198ed91ecd69af387a9336e76233e463713b105b05c
     container_name: fcrepo
     env_file: .env
     ports:

--- a/fcrepo/4.7.5/conf/logging.properties
+++ b/fcrepo/4.7.5/conf/logging.properties
@@ -59,13 +59,13 @@ java.util.logging.ConsoleHandler.formatter = org.apache.juli.OneLineFormatter
 ############################################################
 
 org.apache.catalina.core.ContainerBase.[Catalina].[localhost].level = INFO
-org.apache.catalina.core.ContainerBase.[Catalina].[localhost].handlers = 2localhost.org.apache.juli.AsyncFileHandler
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].handlers = java.util.logging.ConsoleHandler, 2localhost.org.apache.juli.AsyncFileHandler
 
 org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager].level = INFO
-org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager].handlers = 3manager.org.apache.juli.AsyncFileHandler
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager].handlers = java.util.logging.ConsoleHandler, 3manager.org.apache.juli.AsyncFileHandler
 
 org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager].level = INFO
-org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager].handlers = 4host-manager.org.apache.juli.AsyncFileHandler
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager].handlers = java.util.logging.ConsoleHandler, 4host-manager.org.apache.juli.AsyncFileHandler
 
 # For example, set the org.apache.catalina.util.LifecycleBase logger to log
 # each component that extends LifecycleBase changing state:

--- a/fcrepo/4.7.5/conf/server.xml
+++ b/fcrepo/4.7.5/conf/server.xml
@@ -159,9 +159,9 @@
         <!-- Access log processes all example.
              Documentation at: /docs/config/valve.html
              Note: The pattern used is equivalent to using pattern="common" -->
-        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
-               prefix="localhost_access_log" suffix=".txt"
-               pattern="%h %l %u %t &quot;%r&quot; %s %b" />
+        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="/proc/self/fd"
+               prefix="1" suffix="" rotatable="false" buffered="false"
+               pattern="%t %I %a %u %{Eppn}r %s status, %D ms, %b bytes; &quot;%r&quot; %{user-agent}i" />
 
         <Context path="/pass-user-service" docBase="pass-user-service" reloadable="false" />
         <Context path="/fcrepo" docBase="fcrepo" reloadable="true" crossContext="true"/>


### PR DESCRIPTION
* Log tomcat access to console
* Configure other JULI loggers to use console

This should let us easily see _every_ request to the user service and Fedora, as well as the status code, how long it took, the user agent, shib EPPN (if provided), etc