### PR TITLE
[DO NOT MERGE]: Use a one-off image for testing the pass-authz user concurrency fix p…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   fcrepo:
     build:
       context: ./fcrepo/4.7.5
-    image: oapass/fcrepo:4.7.5-3.2-3@sha256:b7036b1f61d84341aea1b198ed91ecd69af387a9336e76233e463713b105b05c
+    image: oapass/pass-authz-fcrepo:0.5.0-SNAPSHOT@sha256:f57caa174b1d1c35cc89c76ee655e0999e61ebadc21271dd08eeefa9c1b28d1b
     container_name: fcrepo
     env_file: .env
     ports:


### PR DESCRIPTION
…resent in https://github.com/OA-PASS/pass-authz/pull/77

## to test

docker-compose up -d
docker logs -f fcrepo

separate window:
docker logs -f notification

wait for fcrepo to be available

perform a search of the index, insuring that the User resource for `newSubmitter5` does not exist: http://pass.local:9200/pass/_search?q=@type:User+locatorIds:*NEWSUB0005*&pretty&default_operator=AND (NO results should be returned)

login to pass.local as `nih-user`, create a new submission on behalf of `newSubmitter5@jhu.edu` (do *not* search for the user, enter their email address).  Complete the submission by requesting approval.  normally I do this a non-incognito browser window.

grab the invite link from the notification terminal window.

open a new browser session in an incognito session. paste in the invite link.  login as `newSubmitter5`.


perform a search of the index, insuring that EXACTLY ONE User resource for `newSubmitter5` exists: http://pass.local:9200/pass/_search?q=@type:User+locatorIds:*NEWSUB0005*&pretty&default_operator=AND

