### PR TITLE
Use patched jar containing submission performance fix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   fcrepo:
     build:
       context: ./fcrepo/4.7.5
-    image: oapass/fcrepo:4.7.5-3.2-4
+    image: oapass/fcrepo:4.7.5-3.2-4@sha256:3769ccf6771745d8fc0e55643a7943932163c9daa707278c58b957bed22f1e75
     container_name: fcrepo
     env_file: .env
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   fcrepo:
     build:
       context: ./fcrepo/4.7.5
-    image: oapass/fcrepo:4.7.5-3.2-3@sha256:b7036b1f61d84341aea1b198ed91ecd69af387a9336e76233e463713b105b05c
+    image: oapass/fcrepo:4.7.5-3.2-4
     container_name: fcrepo
     env_file: .env
     ports:

--- a/fcrepo/4.7.5/Dockerfile
+++ b/fcrepo/4.7.5/Dockerfile
@@ -118,7 +118,11 @@ RUN wget -O ${COMPACTION_PRELOAD_FILE_PASS_STATIC_2_0} \
     wget -O ${CATALINA_HOME}/webapps/fcrepo/WEB-INF/lib/modeshape-jcr-5.4.0-maint-01.jar \
         https://github.com/OA-PASS/modeshape/releases/download/modeshape-5.4.0-maint-01/modeshape-jcr-5.4.0.Final.jar && \
     echo "159697fd2c15db3c9caf47f52f64c453e1ed67a2 *${CATALINA_HOME}/webapps/fcrepo/WEB-INF/lib/modeshape-jcr-5.4.0-maint-01.jar" \
-        | sha1sum -c -
+        | sha1sum -c - && \
+    rm ${CATALINA_HOME}/webapps/fcrepo/WEB-INF/lib/fcrepo-auth-roles-common-4.7.5.jar && \
+    wget -O ${CATALINA_HOME}/webapps/fcrepo/WEB-INF/lib/fcrepo-auth-roles-common-4.7.5-fixes-01.jar \
+      https://github.com/OA-PASS/fcrepo-module-auth-rbacl/releases/download/fixes-4.7.5-0/fcrepo-auth-roles-common-4.7.5.jar && \
+    echo "21d21474ca15fa69741dd9bf66a0f39962eff8bd *${CATALINA_HOME}/webapps/fcrepo/WEB-INF/lib/fcrepo-auth-roles-common-4.7.5-fixes-01.jar"
 
 COPY WEB-INF/ ${CATALINA_HOME}/webapps/fcrepo/WEB-INF/
 


### PR DESCRIPTION
Uses a patched `fcrepo-auth-roles-common` module to cache Fedora's internal lookups of ACLs.  The root cause of the slowdown was an "ACL lookup storm" in Fedora, which seems to be a fundamental consequence of the design, which leverages Modeshape internals in a way that has severe performance implications.

Resolves OA-PASS/general-issues#81