### PR TITLE
Update pass-authz with the 'simple' duplicate fix

### DIFF
--- a/authz/Dockerfile
+++ b/authz/Dockerfile
@@ -1,5 +1,5 @@
 FROM openjdk:8u171-jre-alpine3.8@sha256:e3168174d367db9928bb70e33b4750457092e61815d577e368f53efb29fea48b
-ENV VERSION=0.4.0 \
+ENV VERSION=0.4.2 \
     AUTHZ_MAX_ATTEMPTS=20 \
     PASS_BACKEND_ROLE=http://oapass.org/ns/roles/johnshopkins.edu#pass-backend \
     PASS_GRANTADMIN_ROLE=http://oapass.org/ns/roles/johnshopkins.edu#admin \
@@ -12,7 +12,7 @@ ADD wait_and_start.sh /app
 
 RUN apk add --no-cache ca-certificates wget gettext curl && \
     wget http://central.maven.org/maven2/org/dataconservancy/pass/pass-authz-listener/${VERSION}/pass-authz-listener-${VERSION}-exe.jar && \
-    echo "00bc26f673a6033ac0ad4ba5aaac793b75e2208b *pass-authz-listener-${VERSION}-exe.jar" \
+    echo "c03db17ec427f55496389653490c6b91085d3701 *pass-authz-listener-${VERSION}-exe.jar" \
         | sha1sum -c -  && \
     rm -rf /var/cache/apk/ && \
     chmod 700 wait_and_start.sh 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -207,7 +207,7 @@ services:
 
   authz:
     build: ./authz
-    image: oapass/authz:0.4.0-3.2@sha256:64a5a8e7a4280d990d91ca60dffefbde4ad967547569d13d71e6e0d1aed32492
+    image: oapass/authz:0.4.2-3.2@sha256:c34a87ebf5f7f23b48f58fadad68bc12cd58819c2fc2021331896d71c222462d
     container_name: authz
     env_file: .env
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   fcrepo:
     build:
       context: ./fcrepo/4.7.5
-    image: oapass/fcrepo:4.7.5-3.2-4@sha256:3769ccf6771745d8fc0e55643a7943932163c9daa707278c58b957bed22f1e75
+    image: oapass/fcrepo:4.7.5-3.2-5@sha256:0bc8bcf2b4804c0c4ba11af2ad3f02ec5a24a442b6d50877148c212dc79c20d1
     container_name: fcrepo
     env_file: .env
     ports:

--- a/fcrepo/4.7.5/Dockerfile
+++ b/fcrepo/4.7.5/Dockerfile
@@ -2,7 +2,7 @@ FROM tomcat:8.5.34-jre8-alpine@sha256:fa2bce34c65dc57162d4764f1a3ce7c734c926616b
 
 ENV FCREPO_VERSION=4.7.5 \
 JSONLD_ADDON_VERSION=0.0.6 \
-PASS_AUTHZ_VERSION=0.4.0 \
+PASS_AUTHZ_VERSION=0.4.2 \
 JMS_ADDON_VERSION=0.0.2 \
 FCREPO_HOME=${CATALINA_HOME}/fcrepo4-data \
 FCREPO_HOST=fcrepo \
@@ -69,15 +69,15 @@ RUN apk update && \
         | sha1sum -c -  && \
     wget -O ${CATALINA_HOME}/lib/pass-authz-core-${PASS_AUTHZ_VERSION}-shaded.jar \
         http://central.maven.org/maven2/org/dataconservancy/pass/pass-authz-core/${PASS_AUTHZ_VERSION}/pass-authz-core-${PASS_AUTHZ_VERSION}-shaded.jar && \
-    echo "265c733b0157e5206d7c721603e28283bb622aee *${CATALINA_HOME}/lib/pass-authz-core-${PASS_AUTHZ_VERSION}-shaded.jar" \
+    echo "26305aa2b744c25f0422abf51a8275cbbffc5626 *${CATALINA_HOME}/lib/pass-authz-core-${PASS_AUTHZ_VERSION}-shaded.jar" \
        | sha1sum -c -  && \
     wget -O ${CATALINA_HOME}/lib/pass-authz-roles-${PASS_AUTHZ_VERSION}.jar \
         http://central.maven.org/maven2/org/dataconservancy/pass/pass-authz-roles/${PASS_AUTHZ_VERSION}/pass-authz-roles-${PASS_AUTHZ_VERSION}.jar && \
-    echo "7e3a7e456524c47f4f730d57c0dfb2fd1e81a096 *${CATALINA_HOME}/lib/pass-authz-roles-${PASS_AUTHZ_VERSION}.jar" \
+    echo "4d1485e0cca00fca0c448c551baadac6cd625e20 *${CATALINA_HOME}/lib/pass-authz-roles-${PASS_AUTHZ_VERSION}.jar" \
         | sha1sum -c -  && \
     wget -O ${CATALINA_HOME}/webapps/pass-user-service.war \
         http://central.maven.org/maven2/org/dataconservancy/pass/pass-user-service/${PASS_AUTHZ_VERSION}/pass-user-service-${PASS_AUTHZ_VERSION}.war && \
-    echo "12f2b1052e966bad1e699772a5fb436bc61aabe1 *${CATALINA_HOME}/webapps/pass-user-service.war" \
+    echo "11ef84dee2128edd9b95b8f187f095f1dca920ac *${CATALINA_HOME}/webapps/pass-user-service.war" \
         | sha1sum -c -  && \
     mkdir ${CATALINA_HOME}/webapps/pass-user-service && \
     unzip ${CATALINA_HOME}/webapps/pass-user-service.war -d ${CATALINA_HOME}/webapps/pass-user-service  && \


### PR DESCRIPTION
Same as #178 , except with the alternate fix presented in OA-PASS/pass-authz#78

Previous instructions:
## to test

docker-compose pull
docker-compose up -d
docker logs -f fcrepo

separate window:
docker logs -f notification

wait for fcrepo to be available

perform a search of the index, insuring that the User resource for `newSubmitter5` does not exist: http://pass.local:9200/pass/_search?q=@type:User+locatorIds:*NEWSUB0005*&pretty&default_operator=AND (NO results should be returned)

login to pass.local as `nih-user`, create a new submission on behalf of `newSubmitter5@jhu.edu` (do *not* search for the user, enter their email address).  Complete the submission by requesting approval.  normally I do this a non-incognito browser window.

grab the invite link from the notification terminal window.

open a new browser session in an incognito session. paste in the invite link.  login as `newSubmitter5`.


perform a search of the index, insuring that EXACTLY ONE User resource for `newSubmitter5` exists: http://pass.local:9200/pass/_search?q=@type:User+locatorIds:*NEWSUB0005*&pretty&default_operator=AND

