### PR TITLE
Add SCHEMA_SERVICE_URI environment variable

### DIFF
--- a/.env
+++ b/.env
@@ -16,7 +16,7 @@ EMBER_PORT=81
 
 # Ember app build-time config
 EMBER_GIT_REPO=https://github.com/OA-PASS/pass-ember
-EMBER_GIT_BRANCH=aec1ef8fe225bba9b0646cb0cb1cca54a0ac887c
+EMBER_GIT_BRANCH=5a50f87515c513c9091d4e87431b1174ede42df4
 
 EMBER_ROOT_URL=/app/
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       args:
         EMBER_GIT_REPO: "${EMBER_GIT_REPO}"
         EMBER_GIT_BRANCH: "${EMBER_GIT_BRANCH}"
-    image: oapass/ember:20181127-aec1ef8@sha256:7365cc4b1149907cfbfeb4bcad678b5146dc6c28ab025d94d09bb889759d1ed5
+    image: oapass/ember:20181220-5a50f87@sha256:fbc6379cd3ad03fdc6f87b3c46cef1bf0d0b0e5987e76f92c8079d87a8980af7
     container_name: ember
     env_file: .env
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -245,7 +245,7 @@ services:
       - PASS_NOTIFICATION_CONFIGURATION=file:/notification.json
 
   schemaservice:
-    image: oapass/schema-service:v0.1.0
+    image: oapass/schema-service:v0.1.1
     container_name: schemaservice
     env_file: .env
     ports:

--- a/ember/Dockerfile
+++ b/ember/Dockerfile
@@ -13,6 +13,7 @@ ENV EMBER_GIT_BRANCH=${EMBER_GIT_BRANCH:-master} \
     FEDORA_ADAPTER_PASSWORD="" \    
     FEDORA_ADAPTER_USER="" \
     USER_SERVICE_URL=/pass-user-service/whoami \
+    SCHEMA_SERVICE_URL=/schemaservice \
     EMBER_ROOT_URL=${EMBER_ROOT_URL:-/app/}
 
 RUN apk add --no-cache nodejs-npm git && \


### PR DESCRIPTION
* Adds `SCHEMA_SERVICE_URI` to ember build
* Bumps Ember to latest master

At present, the schema service code in Ember is in [a branch](https://github.com/OA-PASS/pass-ember/tree/routes-refactoring), and not in master.  As a result, the addition of the environment variable in this PR will have no effect until Ember is built against a branch that adds support for the schema service.  

# How to test

Since schema service support is not in pass-ember master, the only way to really test this is to update is to set `EMBER_GIT_BRANCH=3a58c255372949f9c09e5c8001bb297dd7ee1bf8` in `.env`, and build the `ember` image, and do a `docker-compose up -d`.  If you look at the html source of `https://pass.local/app`, you should see the value `/schemaservice` in the environment variable blob.  If you edit the value of `SCHEMA_SERVICE_URI` in `ember/Dockerfile` to some nonsense value and build, you should observe that forms are broken in Ember.  This will prove that Ember is reading and using the environment variable.

Resolves OA-PASS/metadata-schemas#9