### PR TITLE
Run journal loader against assets image.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -174,7 +174,7 @@ services:
       - assets
 
   assets:
-    image: birkland/assets:2019-03-06_3.3@sha256:e4c59e625eaf28cb4524dbe54a4e5dbf11adf71347470afb8810a75274f596c7
+    image: birkland/assets:2019-04-08_3.3@sha256:380fec538483daabdcd413e90a9538725790425c8db63892cbc5059bcf6c0a06
     build: ./assets
     volumes:
       - passdata:/data


### PR DESCRIPTION
Updates ISSNs to have PubType prefix
Adds new PMC type A journals

To test:

* `docker-compose pull`, `docker-compose up -d`
* Look at a few random journals under `https://pass.local/fcrepo/rest/journals`, make sure the `issns` property is prefixed by publication type (`Print:` or `Online:`).
* Look at a few Elasticsearch recirds, via `http://pass.local:9200/pass/_search?q=@type:Journal&pretty`.  Again, verify that `issns` is prefixed with publication type (`Print:` or `Online:`).

Resolves #190 