### PR TITLE
incorporate pass-doi-service into the docker-pass setup

### DIFF
--- a/.env
+++ b/.env
@@ -171,3 +171,6 @@ PASS_EXTERNAL_FEDORA_BASEURL=https://pass.local/fcrepo/rest/
 
 # Policy service
 POLICY_SERVICE_PORT=8088
+
+# DOI Service
+PASS_DOI_SERVICE_PORT=8090

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -264,6 +264,16 @@ services:
       - front
       - back
 
+  doiservice:
+    image: oapass/doi-service:version0.0.1@sha256:23a438caeb1f0d4a6f4daab8585fb2f54e111595d843c08e7c1a1ed6e4e5cf27
+    container_name: doiservice
+    env_file: .env
+    ports:
+      - "${PASS_DOI_SERVICE_PORT}:8080"
+    networks:
+      - front
+      - back
+
 volumes:
   passdata:
     driver: local

--- a/doi-service/0.0.1/Dockerfile
+++ b/doi-service/0.0.1/Dockerfile
@@ -1,0 +1,7 @@
+FROM tomcat
+
+EXPOSE ${pass.doi.service.port}
+
+ADD  target/pass-doi-service.war /usr/local/tomcat/webapps/
+
+CMD ["catalina.sh", "run"]

--- a/httpd-proxy/etc-httpd/conf.d/httpd.conf
+++ b/httpd-proxy/etc-httpd/conf.d/httpd.conf
@@ -113,6 +113,10 @@ EECDH EDH+aRSA !aNULL !eNULL !LOW !3DES !MD5 !EXP !PSK !SRP !DSS !RC4"
     ProxyPass / http://static-html:82/
     ProxyPassReverse / http://static-html:82/
 
+    # DOI service
+    ProxyPass /doiservice http://sp/doiservice
+    ProxyPassReverse /doiservice http://sp/doiservice
+
 </VirtualHost>
 
 <IfModule log_config_module>

--- a/sp/2.6.1/etc-httpd/conf.d/sp.conf
+++ b/sp/2.6.1/etc-httpd/conf.d/sp.conf
@@ -51,6 +51,14 @@ AllowEncodedSlashes NoDecode
         require shib-session
     </Location>
 
+    <Location /doiservice>
+        AuthType shibboleth
+        ShibRequestSetting requireSession 1
+        ShibUseHeaders On
+        require shib-session
+    </Location>
+
+
     ProxyPreserveHost on
     RequestHeader set X-Forwarded-Proto "https" env=HTTPS
     RequestHeader set REMOTE_USER %{REMOTE_USER}s


### PR DESCRIPTION
added section for doi-service to the YAML file, updated configs for httpd-proxy amd sp, and .env 