### PR TITLE
Bump schema service to latest release

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -245,7 +245,7 @@ services:
       - PASS_NOTIFICATION_CONFIGURATION=file:/notification.json
 
   schemaservice:
-    image: oapass/schema-service:v0.1.1
+    image: oapass/schema-service:v0.2.1@sha256:e19e5909155d605d465ca70df55acb14cdeac8a1ffe5bbb2de44b3298d734013
     container_name: schemaservice
     env_file: .env
     ports:


### PR DESCRIPTION
This is a trivial change, and probably can't be easily tested without an Ember version that hits the schema service.  Therefore, just make sure it pulls and runs

* `docker-compose pull`
* `docker-compose up -d`
* `docker logs schemaservice`.  You should see the logs end with `Listening on port 8086`

Resolves #196 