### PR TITLE
Use latest authz release, JVM DNS ttl tweak

### DIFF
--- a/authz/Dockerfile
+++ b/authz/Dockerfile
@@ -1,5 +1,5 @@
-FROM openjdk:8u171-jre-alpine3.8@sha256:e3168174d367db9928bb70e33b4750457092e61815d577e368f53efb29fea48b
-ENV VERSION=0.4.3 \
+FROM openjdk:8u212-jre-alpine3.9@sha256:5c5867cd2d4d198d1e53562c8202dfa388832b6f7d8276e69eae212b326c7777
+ENV VERSION=0.4.4 \
     AUTHZ_MAX_ATTEMPTS=20 \
     PASS_BACKEND_ROLE=http://oapass.org/ns/roles/johnshopkins.edu#pass-backend \
     PASS_GRANTADMIN_ROLE=http://oapass.org/ns/roles/johnshopkins.edu#admin \
@@ -12,9 +12,10 @@ ADD wait_and_start.sh /app
 
 RUN apk add --no-cache ca-certificates wget gettext curl && \
     wget http://central.maven.org/maven2/org/dataconservancy/pass/pass-authz-listener/${VERSION}/pass-authz-listener-${VERSION}-exe.jar && \
-    echo "c200b8f6f288c21ee690c2c7c7234ba43cc81f55 *pass-authz-listener-${VERSION}-exe.jar" \
+    echo "9a869f8e0998d3406c240c1ca54a23fe2c48f0a7 *pass-authz-listener-${VERSION}-exe.jar" \
         | sha1sum -c -  && \
     rm -rf /var/cache/apk/ && \
-    chmod 700 wait_and_start.sh 
+    chmod 700 wait_and_start.sh && \
+    echo "networkaddress.cache.ttl=10" >> ${JAVA_HOME}/lib/security/java.security
 
 CMD ./wait_and_start.sh pass-authz-listener-${VERSION}-exe.jar

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   fcrepo:
     build:
       context: ./fcrepo/4.7.5
-    image: oapass/fcrepo:4.7.5-3.4@sha256:3e39b01edf56c149279cfc51b647df335c01f9ec38036f1724f337ae35d68fe8
+    image: oapass/fcrepo:4.7.5-3.4-1@sha256:56faf95a9753f2548665de0154888221a7c02ae2158489d08ec5499ed7ceb3fd
     container_name: fcrepo
     env_file: .env
     ports:
@@ -206,7 +206,7 @@ services:
 
   authz:
     build: ./authz
-    image: oapass/authz:0.4.3-3.2@sha256:8739851bee894a77d207e420fe86b64b6df1fd02f17cbcc60275513026d13f3d
+    image: oapass/authz:0.4.4-3.4@sha256:a8f97298b613708775f22ad70a0dca59005d15143c77292533c51110933b7fde
     container_name: authz
     env_file: .env
     networks:

--- a/fcrepo/4.7.5/Dockerfile
+++ b/fcrepo/4.7.5/Dockerfile
@@ -1,8 +1,8 @@
-FROM tomcat:8.5.39-jre8-alpine@sha256:fa2bce34c65dc57162d4764f1a3ce7c734c926616b692d9afbcf57496e1f9d4c
+FROM tomcat:8.5.40-jre8-alpine@sha256:3bfda84777039e5150a74bfdff71979d1cb7106d74382a735a80f18b5d6d2ebb
 
 ENV FCREPO_VERSION=4.7.5 \
 JSONLD_ADDON_VERSION=0.0.6 \
-PASS_AUTHZ_VERSION=0.4.3 \
+PASS_AUTHZ_VERSION=0.4.4 \
 JMS_ADDON_VERSION=0.0.2 \
 FCREPO_HOME=${CATALINA_HOME}/fcrepo4-data \
 FCREPO_HOST=fcrepo \
@@ -73,15 +73,15 @@ RUN apk update && \
         | sha1sum -c -  && \
     wget -O ${CATALINA_HOME}/lib/pass-authz-core-${PASS_AUTHZ_VERSION}-shaded.jar \
         http://central.maven.org/maven2/org/dataconservancy/pass/pass-authz-core/${PASS_AUTHZ_VERSION}/pass-authz-core-${PASS_AUTHZ_VERSION}-shaded.jar && \
-    echo "5452244709c27e4ced16a4d306c98bb9e27e1c69 *${CATALINA_HOME}/lib/pass-authz-core-${PASS_AUTHZ_VERSION}-shaded.jar" \
+    echo "622ad18d2f062e761426a5b0ec71f222794e5fbd *${CATALINA_HOME}/lib/pass-authz-core-${PASS_AUTHZ_VERSION}-shaded.jar" \
        | sha1sum -c -  && \
     wget -O ${CATALINA_HOME}/lib/pass-authz-roles-${PASS_AUTHZ_VERSION}.jar \
         http://central.maven.org/maven2/org/dataconservancy/pass/pass-authz-roles/${PASS_AUTHZ_VERSION}/pass-authz-roles-${PASS_AUTHZ_VERSION}.jar && \
-    echo "ccddd9161eb8b81edfb45104fb87a9217f5d2004 *${CATALINA_HOME}/lib/pass-authz-roles-${PASS_AUTHZ_VERSION}.jar" \
+    echo "671c6f3d086124f2033ac51794d95a250a222d28 *${CATALINA_HOME}/lib/pass-authz-roles-${PASS_AUTHZ_VERSION}.jar" \
         | sha1sum -c -  && \
     wget -O ${CATALINA_HOME}/webapps/pass-user-service.war \
         http://central.maven.org/maven2/org/dataconservancy/pass/pass-user-service/${PASS_AUTHZ_VERSION}/pass-user-service-${PASS_AUTHZ_VERSION}.war && \
-    echo "ddde99f6a56deda705023a1d96b75407b2917a60 *${CATALINA_HOME}/webapps/pass-user-service.war" \
+    echo "48c13c3848d0b50370cdedb8fbcd0c5d3816199d *${CATALINA_HOME}/webapps/pass-user-service.war" \
         | sha1sum -c -  && \
     mkdir ${CATALINA_HOME}/webapps/pass-user-service && \
     unzip ${CATALINA_HOME}/webapps/pass-user-service.war -d ${CATALINA_HOME}/webapps/pass-user-service  && \
@@ -130,7 +130,8 @@ RUN wget -O ${COMPACTION_PRELOAD_FILE_PASS_STATIC_2_0} \
     rm ${CATALINA_HOME}/webapps/fcrepo/WEB-INF/lib/fcrepo-auth-roles-common-4.7.5.jar && \
     wget -O ${CATALINA_HOME}/webapps/fcrepo/WEB-INF/lib/fcrepo-auth-roles-common-4.7.5-fixes-01.jar \
       https://github.com/OA-PASS/fcrepo-module-auth-rbacl/releases/download/fixes-4.7.5-0/fcrepo-auth-roles-common-4.7.5.jar && \
-    echo "21d21474ca15fa69741dd9bf66a0f39962eff8bd *${CATALINA_HOME}/webapps/fcrepo/WEB-INF/lib/fcrepo-auth-roles-common-4.7.5-fixes-01.jar"
+    echo "21d21474ca15fa69741dd9bf66a0f39962eff8bd *${CATALINA_HOME}/webapps/fcrepo/WEB-INF/lib/fcrepo-auth-roles-common-4.7.5-fixes-01.jar" && \
+    echo "networkaddress.cache.ttl=10" >> ${JAVA_HOME}/lib/security/java.security
 
 COPY WEB-INF/ ${CATALINA_HOME}/webapps/fcrepo/WEB-INF/
 


### PR DESCRIPTION
* Uses pass-authz 0.4.4 (which uses client 0.6.0)
* Sets DNS ttl to 10 seconds, to deal with services that chage their IP
address
* Uses latest patch release of openjdk

The updates in this PR have no observable effect, so to test it, just verify that nothing seems any more broken than it already is.

Partially addresses #205 