### PR TITLE
Update JVM and DNS ttl settings for indexer and notification services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,7 +145,7 @@ services:
 
   indexer:
     build: ./indexer/0.0.18-SNAPSHOT
-    image: oapass/indexer:0.0.18-3.4@sha256:e51092a9d433219d52207f1ec3f5ea7c652d51f516bcbe9434dae556b921546d
+    image: oapass/indexer:0.0.18-3.4-1@sha256:3375ea702e0a1c7a5e0e7e06635d28e49af436aeb1c3d88a03d4cb494d7b40bf
     container_name: indexer
     env_file: .env
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   fcrepo:
     build:
       context: ./fcrepo/4.7.5
-    image: oapass/fcrepo:4.7.5-3.4@sha256:3e39b01edf56c149279cfc51b647df335c01f9ec38036f1724f337ae35d68fe8
+    image: oapass/fcrepo:4.7.5-3.4-1@sha256:56faf95a9753f2548665de0154888221a7c02ae2158489d08ec5499ed7ceb3fd
     container_name: fcrepo
     env_file: .env
     ports:
@@ -206,7 +206,7 @@ services:
 
   authz:
     build: ./authz
-    image: oapass/authz:0.4.3-3.2@sha256:8739851bee894a77d207e420fe86b64b6df1fd02f17cbcc60275513026d13f3d
+    image: oapass/authz:0.4.4-3.4@sha256:a8f97298b613708775f22ad70a0dca59005d15143c77292533c51110933b7fde
     container_name: authz
     env_file: .env
     networks:
@@ -233,7 +233,7 @@ services:
 
   notification:
     build: notification-services/0.0.2-3.2
-    image: oapass/notification-services:0.0.2-3.2@sha256:7a693ce4005c88bdf93104d1cea1caec569dbb994ad8eaa07150dcd815a0e002
+    image: oapass/notification-services:0.0.2-3.2-1@sha256:5475490671d2c630f89265c44736f74d4520b84cf5b239c29b5c74678762a2e9
     container_name: notification
     networks:
       - back

--- a/indexer/0.0.18-SNAPSHOT/Dockerfile
+++ b/indexer/0.0.18-SNAPSHOT/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8u151-jre-alpine3.7@sha256:795d1c079217bdcbff740874b78ddea80d5df858b3999951a33871ee61de15ce
+FROM openjdk:8u212-jre-alpine3.9@sha256:5c5867cd2d4d198d1e53562c8202dfa388832b6f7d8276e69eae212b326c7777
 
 ENV PI_VERSION=0.0.18 \
 PI_MAX_ATTEMPTS=20 \
@@ -16,6 +16,7 @@ RUN apk add --no-cache ca-certificates wget gettext curl && \
         | sha1sum -c -  && \
     wget https://oa-pass.github.io/pass-data-model/src/main/resources/esconfig-${ESCONFIG_VERSION}.json && \
     rm -rf /var/cache/apk/ && \
-    chmod 700 wait_and_start.sh 
+    chmod 700 wait_and_start.sh && \
+    echo "networkaddress.cache.ttl=10" >> ${JAVA_HOME}/lib/security/java.security
 
 CMD ./wait_and_start.sh pass-indexer-cli-${PI_VERSION}-SNAPSHOT-shaded.jar

--- a/notification-services/0.0.2-3.2/Dockerfile
+++ b/notification-services/0.0.2-3.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8u151-jre-alpine3.7
+FROM openjdk:8u212-jre-alpine3.9@sha256:5c5867cd2d4d198d1e53562c8202dfa388832b6f7d8276e69eae212b326c7777
 
 ENV NOTIFICATION_SERVICES_VERSION=0.0.2-3.2 \
     JSONLD_CONTEXT_VERSION=3.2 \
@@ -21,7 +21,9 @@ ENV NOTIFICATION_SERVICES_VERSION=0.0.2-3.2 \
 RUN apk update && \
     apk add --no-cache wget && \
     wget -O notification-services.jar \
-        http://repo1.maven.org/maven2/org/dataconservancy/pass/notify/notification-boot/${NOTIFICATION_SERVICES_VERSION}/notification-boot-${NOTIFICATION_SERVICES_VERSION}-exec.jar
+        http://repo1.maven.org/maven2/org/dataconservancy/pass/notify/notification-boot/${NOTIFICATION_SERVICES_VERSION}/notification-boot-${NOTIFICATION_SERVICES_VERSION}-exec.jar && \
+    echo "networkaddress.cache.ttl=10" >> ${JAVA_HOME}/lib/security/java.security
+    
 
 COPY entrypoint.sh /
 


### PR DESCRIPTION
* Sets DNS ttl to 10 seconds, to deal with services that chage their IP
address
* Uses latest patch release of openjdk

The updates in this PR have no observable effect, so to test it, just verify that nothing seems any more broken than it already is.

Partially addresses #205 