### PR TITLE
Bump schema service to v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ To configure the Docker images, open up the `.env` file and make any necessary c
 - PASS_DEPOSIT_QUEUE_DEPOSIT_NAME: the name of the queue (managed by the ActiveMQ container) that emits messages relating to `Deposit` resources
 
 A [full](https://github.com/OA-PASS/deposit-services#production-configuration-variables) listing of supported variables for Deposit Services are found [here](https://github.com/OA-PASS/deposit-services#production-configuration-variables).
+
+### Schema service variables
+- PASS_EXTERNAL_FEDORA_BASEURL:  External (public) PASS baseurl (e.g. https://pass.local/fcrepo/rest)
+- PASS_FEDORA_BASEURL: Internal (private) PASS baseurl (e.g. http://localhost:8080/fcrepo/rest)
+- PASS_FEDORA_USER:  Username for basic auth to Fedora (default: "fedoraAdmin")
+- PASS_FEDORA_PASSWORD: Password for basic auth to Fedora (default: "moo")
+- SCHEMA_SERVICE_PORT: The port the schema service is served on (default: random)
+
+
 ### Policy service variables
 
 - PASS_EXTERNAL_FEDORA_BASEURL:  External (public) PASS baseurl (e.g. https://pass.local/fcrepo/rest)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -244,7 +244,7 @@ services:
       - PASS_NOTIFICATION_CONFIGURATION=file:/notification.json
 
   schemaservice:
-    image: oapass/schema-service:v0.2.1-1-gb28397@sha256:3a2435f58e7125ff2f5ad150c40fe6767ab1e1be428401b225f5204ed4d8cdda
+    image: oapass/schema-service:v0.3.0@sha256:2823e9ee3870f0000ba60205cf0c6df6e9c66244ce357ee6e61d2bac9fc034f2
     container_name: schemaservice
     env_file: .env
     ports:


### PR DESCRIPTION
This contains a dataTime format fix, as well as more strict ISSN
validation for NIHMS deposits

Partially resolves #213 