### PR TITLE
Bump policy service to v0.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ To configure the Docker images, open up the `.env` file and make any necessary c
 - PASS_DEPOSIT_QUEUE_DEPOSIT_NAME: the name of the queue (managed by the ActiveMQ container) that emits messages relating to `Deposit` resources
 
 A [full](https://github.com/OA-PASS/deposit-services#production-configuration-variables) listing of supported variables for Deposit Services are found [here](https://github.com/OA-PASS/deposit-services#production-configuration-variables).
+### Policy service variables
+
+- PASS_EXTERNAL_FEDORA_BASEURL:  External (public) PASS baseurl (e.g. https://pass.local/fcrepo/rest)
+- PASS_FEDORA_BASEURL: Internal (private) PASS baseurl (e.g. http://localhost:8080/fcrepo/rest)
+- PASS_FEDORA_USER:  Username for basic auth to Fedora (default: "fedoraAdmin")
+- PASS_FEDORA_PASSWORD: Password for basic auth to Fedora (default: "moo")
+- POLICY_FILE: Location of the policy DSL file.  Baked-in values are `docker.json` (default), and `aws.json` (works in the AWS environment)
   
 ### Postgres-related variables
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -254,7 +254,7 @@ services:
       - back
   
   policyservice:
-    image: oapass/policy-service:v0.1.1@sha256:7eec368c7da024c1a3a955e80c2185928f86188e2e870ed9bf11846dc0153980
+    image: oapass/policy-service:v0.1.2@sha256:b361bc7dd9d366465f7683052e038e5ec93ef77a48e69176590c84044ce7d804
     container_name: policyservice
     env_file: .env
     ports:


### PR DESCRIPTION
This has no changes for pass-docker, but does have a configuration file
`aws.json` usable in AWS`

Partially addresses #213 