### PR TITLE
Correct NIH FTP configuration

### DIFF
--- a/.env
+++ b/.env
@@ -4,6 +4,13 @@ FTP_PORT=21
 FTP_USER=nihmsftpuser
 FTP_PASS=nihmsftppass
 
+# For testing with NIH-administered FTP staging server
+# (comment out the above FTP_* variables, add correct password)
+#FTP_HOST=ftp-private.ncbi.nlm.nih.gov
+#FTP_PORT=21
+#FTP_USER=JHU_DC_TEST
+#FTP_PASS=<password>
+
 # Static html server runtime config
 STATIC_HTML_PORT=82
 

--- a/deposit-services/1.0.0-3.4/repositories.json
+++ b/deposit-services/1.0.0-3.4/repositories.json
@@ -46,22 +46,12 @@
     }
   },
   "pmc": {
-    "deposit-config": {
-      "processing": {
-      },
-      "mapping": {
-        "INFO": "accepted",
-        "ERROR": "rejected",
-        "WARN": "rejected",
-        "default-mapping": "submitted"
-      }
-    },
     "assembler": {
       "specification": "nihms-native-2017-07",
       "beanName": "nihmsAssembler",
       "options": {
-        "archive": "ZIP",
-        "compression": "NONE",
+        "archive": "TAR",
+        "compression": "GZIP",
         "algorithms": [
           "sha512",
           "md5"
@@ -78,7 +68,7 @@
         "data-type": "binary",
         "transfer-mode": "stream",
         "use-pasv": true,
-        "default-directory": "/logs/upload/%s"
+        "default-directory": "/upload/%s"
       }
     }
   }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -188,7 +188,7 @@ services:
 
   deposit:
     build: ./deposit-services/1.0.0-3.4
-    image: oapass/deposit-pass-docker:1.0.0-3.4-SNAPSHOT@sha256:3ec7c322518150a236369ed91a100f54c65d641ca9239ef46228d852237b8bfa
+    image: oapass/deposit-pass-docker:1.0.0-3.4-SNAPSHOT@sha256:299e8c6bb8a861e2147f13d728fee898e61d2be5554ae405d8ddb29b50419fe8
     container_name: deposit
     env_file: .env
     environment:


### PR DESCRIPTION
This PR corrects the NIHMS/PMC FTP configuration parameters in `repositories.json`, and updates the image tag.

It also updates the environment (`.env` file) with NIH FTP connection parameters that can be commented out for use.