### PR TITLE
Update Ember and pass-docker environment

### DIFF
--- a/.env
+++ b/.env
@@ -173,11 +173,14 @@ PASS_NOTIFICATION_PRODUCTION_FROM_ADDRESS=noreply@pass.jh.edu
 PASS_NOTIFICATION_PRODUCTION_GLOBAL_CC_ADDRESS=
 
 # Schema service
+SCHEMA_SERVICE_URL=https://pass.local:8086
 SCHEMA_SERVICE_PORT=8086
 PASS_EXTERNAL_FEDORA_BASEURL=https://pass.local/fcrepo/rest/
 
 # Policy service
+POLICY_SERVICE_URL=https://pass.local:8088/policyservice
 POLICY_SERVICE_PORT=8088
 
 # DOI Service
+DOI_SERVICE_URL=https://pass.local:8090/doiservice/journal
 PASS_DOI_SERVICE_PORT=8090

--- a/.env
+++ b/.env
@@ -173,14 +173,13 @@ PASS_NOTIFICATION_PRODUCTION_FROM_ADDRESS=noreply@pass.jh.edu
 PASS_NOTIFICATION_PRODUCTION_GLOBAL_CC_ADDRESS=
 
 # Schema service
-SCHEMA_SERVICE_URL=https://pass.local:8086
 SCHEMA_SERVICE_PORT=8086
 PASS_EXTERNAL_FEDORA_BASEURL=https://pass.local/fcrepo/rest/
 
 # Policy service
-POLICY_SERVICE_URL=https://pass.local:8088/policyservice
+POLICY_SERVICE_URL=/policyservice
 POLICY_SERVICE_PORT=8088
 
 # DOI Service
-DOI_SERVICE_URL=https://pass.local:8090/doiservice/journal
+DOI_SERVICE_URL=/doiservice/journal
 PASS_DOI_SERVICE_PORT=8090

--- a/.env
+++ b/.env
@@ -23,7 +23,7 @@ EMBER_PORT=81
 
 # Ember app build-time config
 EMBER_GIT_REPO=https://github.com/OA-PASS/pass-ember
-EMBER_GIT_BRANCH=ab7204fb35627274bb37cc7cc3065a8642126a24
+EMBER_GIT_BRANCH=48465ee748ae7d446b4fc72ea995fceb1c303061
 
 EMBER_ROOT_URL=/app/
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To configure the Docker images, open up the `.env` file and make any necessary c
   - The Ember code base will be downloaded and built from `EMBER_GIT_REPO`, using the branch or tag defined in `EMBER_GIT_BRANCH`
   - DOI_SERVICE_URL: The relative URL of the DOI service, used at `ember` image _build time_, not run time (default: `/doiservice/journal`)
   - POLICY_SERVICE_URL: The relative URL of the schema service, used at `ember` image _build time_, not run time (default: `/policyservice`)
-  - USER_SERVICE_URL: The relative URL of the user service, used at `ember` image _build time_, not run time (default: `/pass-user-service`)
+  - USER_SERVICE_URL: The relative URL of the user service, used at `ember` image _build time_, not run time (default: `/pass-user-service/whoami`)
 
 
 ### Fedora-related variables

--- a/README.md
+++ b/README.md
@@ -104,11 +104,14 @@ A [full](https://github.com/OA-PASS/deposit-services#production-configuration-va
 - PASS_FEDORA_BASEURL: Internal (private) PASS baseurl (e.g. http://localhost:8080/fcrepo/rest)
 - PASS_FEDORA_USER:  Username for basic auth to Fedora (default: "fedoraAdmin")
 - PASS_FEDORA_PASSWORD: Password for basic auth to Fedora (default: "moo")
-- SCHEMA_SERVICE_PORT: The port the schema service is served on (default: random)
+- SCHEMA_SERVICE_PORT: The port the schema service is served on (default: `8086`)
+- SCHEMA_SERVICE_URL: The public URL of the schema service (e.g. `https://pass.local:8086`)
 
 ### DOI service variables
 The service will look for an environment variable called PASS_DOI_SERVICE_MAILTO to specify a value on the User-Agent header on the Crossref request. If not present, the default is pass@jhu.edu. The service will require the following environment variables for the java client for Fedora if the defaults are not to be used:
 
+- DOI_SERVICE_URL: The public URL of the DOI service (e.g. `https://pass.local:8090/doiservice/journal`)
+- DOI_SERVICE_PORT: The port the DOI service is served on (default: `8090`)
 - PASS_FEDORA_USER
 - PASS_FEDORA_PASSWORD
 - PASS_FEDORA_BASEURL
@@ -123,7 +126,8 @@ In addition we need PASS_EXTERNAL_FEDORA_BASEURL to be present to translate inte
 - PASS_FEDORA_BASEURL: Internal (private) PASS baseurl (e.g. http://localhost:8080/fcrepo/rest)
 - PASS_FEDORA_USER:  Username for basic auth to Fedora (default: "fedoraAdmin")
 - PASS_FEDORA_PASSWORD: Password for basic auth to Fedora (default: "moo")
-- POLICY_SERVICE_PORT: The port the schema service is served on (default: random)
+- POLICY_SERVICE_PORT: The port the schema service is served on (default: `8088`)
+- POLICY_SERVICE_URL: The public URL of the schema service (e.g. `http://pass.local:8088/policyservice`)
 - POLICY_FILE: Location of the policy DSL file.  Baked-in values are `docker.json` (default), and `aws.json` (works in the AWS environment)
 
 ### Authz service variables

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ To configure the Docker images, open up the `.env` file and make any necessary c
   
   - EMBER_PORT: the Ember HTTP application is served on this port
   - The Ember code base will be downloaded and built from `EMBER_GIT_REPO`, using the branch or tag defined in `EMBER_GIT_BRANCH`
+  - DOI_SERVICE_URL: The relative URL of the DOI service, used at `ember` image _build time_, not run time (default: `/doiservice/journal`)
+  - POLICY_SERVICE_URL: The relative URL of the schema service, used at `ember` image _build time_, not run time (default: `/policyservice`)
+  - USER_SERVICE_URL: The relative URL of the user service, used at `ember` image _build time_, not run time (default: `/pass-user-service`)
+
 
 ### Fedora-related variables
 
@@ -109,7 +113,6 @@ A [full](https://github.com/OA-PASS/deposit-services#production-configuration-va
 ### DOI service variables
 The service will look for an environment variable called PASS_DOI_SERVICE_MAILTO to specify a value on the User-Agent header on the Crossref request. If not present, the default is pass@jhu.edu. The service will require the following environment variables for the java client for Fedora if the defaults are not to be used:
 
-- DOI_SERVICE_URL: The relative URL of the DOI service (e.g. `/doiservice/journal`)
 - DOI_SERVICE_PORT: The port the DOI service is served on (default: `8090`)
 - PASS_FEDORA_USER
 - PASS_FEDORA_PASSWORD
@@ -126,7 +129,6 @@ In addition we need PASS_EXTERNAL_FEDORA_BASEURL to be present to translate inte
 - PASS_FEDORA_USER:  Username for basic auth to Fedora (default: "fedoraAdmin")
 - PASS_FEDORA_PASSWORD: Password for basic auth to Fedora (default: "moo")
 - POLICY_SERVICE_PORT: The port the schema service is served on (default: `8088`)
-- POLICY_SERVICE_URL: The relative URL of the schema service (e.g. `/policyservice`)
 - POLICY_FILE: Location of the policy DSL file.  Baked-in values are `docker.json` (default), and `aws.json` (works in the AWS environment)
 
 ### Authz service variables

--- a/README.md
+++ b/README.md
@@ -105,12 +105,11 @@ A [full](https://github.com/OA-PASS/deposit-services#production-configuration-va
 - PASS_FEDORA_USER:  Username for basic auth to Fedora (default: "fedoraAdmin")
 - PASS_FEDORA_PASSWORD: Password for basic auth to Fedora (default: "moo")
 - SCHEMA_SERVICE_PORT: The port the schema service is served on (default: `8086`)
-- SCHEMA_SERVICE_URL: The public URL of the schema service (e.g. `https://pass.local:8086`)
 
 ### DOI service variables
 The service will look for an environment variable called PASS_DOI_SERVICE_MAILTO to specify a value on the User-Agent header on the Crossref request. If not present, the default is pass@jhu.edu. The service will require the following environment variables for the java client for Fedora if the defaults are not to be used:
 
-- DOI_SERVICE_URL: The public URL of the DOI service (e.g. `https://pass.local:8090/doiservice/journal`)
+- DOI_SERVICE_URL: The relative URL of the DOI service (e.g. `/doiservice/journal`)
 - DOI_SERVICE_PORT: The port the DOI service is served on (default: `8090`)
 - PASS_FEDORA_USER
 - PASS_FEDORA_PASSWORD
@@ -127,7 +126,7 @@ In addition we need PASS_EXTERNAL_FEDORA_BASEURL to be present to translate inte
 - PASS_FEDORA_USER:  Username for basic auth to Fedora (default: "fedoraAdmin")
 - PASS_FEDORA_PASSWORD: Password for basic auth to Fedora (default: "moo")
 - POLICY_SERVICE_PORT: The port the schema service is served on (default: `8088`)
-- POLICY_SERVICE_URL: The public URL of the schema service (e.g. `http://pass.local:8088/policyservice`)
+- POLICY_SERVICE_URL: The relative URL of the schema service (e.g. `/policyservice`)
 - POLICY_FILE: Location of the policy DSL file.  Baked-in values are `docker.json` (default), and `aws.json` (works in the AWS environment)
 
 ### Authz service variables

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       args:
         EMBER_GIT_REPO: "${EMBER_GIT_REPO}"
         EMBER_GIT_BRANCH: "${EMBER_GIT_BRANCH}"
-    image: oapass/ember:20190530-ab7204f@sha256:8507acc52e3eec9ad65ff08993e1d97479547d1f7b974eb26afdddf0a7f30763
+    image: oapass/ember:20190530-48465ee@sha256:d3ec31a4d23a1bf5ce77703b5fa221911851bd8f80d5e0df29fc3feb24b8c592
     container_name: ember
     env_file: .env
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
         POLICY_SERVICE_URL: "${POLICY_SERVICE_URL}"
         USER_SERVICE_URL: "${USER_SERVICE_URL}"
         DOI_SERVICE_URL: "${DOI_SERVICE_URL}"
-    image: oapass/ember:20190530-48465ee
+    image: oapass/ember:20190530-48465ee@sha256:79e7a87a46d7ac198f28fd3419f31e9bd914d0f450ad92619b21c4a146dbde02
     container_name: ember
     env_file: .env
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,10 @@ services:
       args:
         EMBER_GIT_REPO: "${EMBER_GIT_REPO}"
         EMBER_GIT_BRANCH: "${EMBER_GIT_BRANCH}"
-    image: oapass/ember:20190530-48465ee@sha256:d3ec31a4d23a1bf5ce77703b5fa221911851bd8f80d5e0df29fc3feb24b8c592
+        POLICY_SERVICE_URL: "${POLICY_SERVICE_URL}"
+        USER_SERVICE_URL: "${USER_SERVICE_URL}"
+        DOI_SERVICE_URL: "${DOI_SERVICE_URL}"
+    image: oapass/ember:20190530-48465ee
     container_name: ember
     env_file: .env
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       args:
         EMBER_GIT_REPO: "${EMBER_GIT_REPO}"
         EMBER_GIT_BRANCH: "${EMBER_GIT_BRANCH}"
-    image: oapass/ember:20190514-ab7204f@sha256:86356247d5e57e5f551ff8b8648317d65333dcd8f135051bef9e4bf275f3817a
+    image: oapass/ember:20190530-ab7204f@sha256:8507acc52e3eec9ad65ff08993e1d97479547d1f7b974eb26afdddf0a7f30763
     container_name: ember
     env_file: .env
     networks:

--- a/ember/Dockerfile
+++ b/ember/Dockerfile
@@ -12,10 +12,10 @@ ENV EMBER_GIT_BRANCH=${EMBER_GIT_BRANCH:-master} \
     FEDORA_ADAPTER_ES=/es/ \
     FEDORA_ADAPTER_PASSWORD="" \    
     FEDORA_ADAPTER_USER="" \
-    USER_SERVICE_URL=/pass-user-service/whoami \
-    SCHEMA_SERVICE_URL=/schemaservice \
-    DOI_SERVICE_URL=/doiservice/journal \
-    POLICY_SERVICE_URL=/policies \
+    USER_SERVICE_URL=${USER_SERVICE_URL:-/pass-user-service/whoami} \
+    SCHEMA_SERVICE_URL=${SCHEMA_SERVICE_URL:-/schemaservice} \
+    DOI_SERVICE_URL=${DOI_SERVICE_URL:-/doiservice/journal} \
+    POLICY_SERVICE_URL=${POLICY_SERVICE_URL:-/policies} \
     EMBER_ROOT_URL=${EMBER_ROOT_URL:-/app/}
 
 RUN apk add --no-cache nodejs-npm git && \

--- a/ember/Dockerfile
+++ b/ember/Dockerfile
@@ -14,6 +14,8 @@ ENV EMBER_GIT_BRANCH=${EMBER_GIT_BRANCH:-master} \
     FEDORA_ADAPTER_USER="" \
     USER_SERVICE_URL=/pass-user-service/whoami \
     SCHEMA_SERVICE_URL=/schemaservice \
+    DOI_SERVICE_URL=/doiservice/journal \
+    POLICY_SERVICE_URL=/policies \
     EMBER_ROOT_URL=${EMBER_ROOT_URL:-/app/}
 
 RUN apk add --no-cache nodejs-npm git && \

--- a/ember/Dockerfile
+++ b/ember/Dockerfile
@@ -3,6 +3,10 @@ FROM alpine:3.7 as ember-builder
 ARG EMBER_GIT_REPO
 ARG EMBER_GIT_BRANCH
 ARG EMBER_ROOT_URL
+ARG USER_SERVICE_URL
+ARG SCHEMA_SERVICE_URL
+ARG DOI_SERVICE_URL
+ARG POLICY_SERVICE_URL
 
 ENV EMBER_GIT_BRANCH=${EMBER_GIT_BRANCH:-master} \
     EMBER_GIT_REPO=${EMBER_GIT_REPO:-https://github.com/OA-PASS/pass-ember} \
@@ -25,6 +29,8 @@ RUN apk add --no-cache nodejs-npm git && \
     git checkout ${EMBER_GIT_BRANCH} && \
     npm install && \
     npm install -g ember-cli && \
+    echo "Build environment: " && \
+    env | sort && \
     ember build --environment=production
 
 FROM nginx:1.13.12-alpine


### PR DESCRIPTION
Updates the pass-docker environment with additional vars for new services.
Defines relative URLs for new services.
Updates `ember` image with a new build that includes the new environment.

A `SCHEMA_SERVICE_URL` is not needed, since it answers to the root url.