### PR TITLE
Update pass-user-service to create User resources with a first and last name

### DIFF
--- a/authz/Dockerfile
+++ b/authz/Dockerfile
@@ -1,5 +1,5 @@
 FROM openjdk:8u212-jre-alpine3.9@sha256:5c5867cd2d4d198d1e53562c8202dfa388832b6f7d8276e69eae212b326c7777
-ENV VERSION=0.4.4 \
+ENV VERSION=0.4.5 \
     AUTHZ_MAX_ATTEMPTS=20 \
     PASS_BACKEND_ROLE=http://oapass.org/ns/roles/johnshopkins.edu#pass-backend \
     PASS_GRANTADMIN_ROLE=http://oapass.org/ns/roles/johnshopkins.edu#admin \
@@ -12,7 +12,7 @@ ADD wait_and_start.sh /app
 
 RUN apk add --no-cache ca-certificates wget gettext curl && \
     wget http://central.maven.org/maven2/org/dataconservancy/pass/pass-authz-listener/${VERSION}/pass-authz-listener-${VERSION}-exe.jar && \
-    echo "9a869f8e0998d3406c240c1ca54a23fe2c48f0a7 *pass-authz-listener-${VERSION}-exe.jar" \
+    echo "6a9f87c97d090ea108112b2651d804d3da9572b6 *pass-authz-listener-${VERSION}-exe.jar" \
         | sha1sum -c -  && \
     rm -rf /var/cache/apk/ && \
     chmod 700 wait_and_start.sh && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   fcrepo:
     build:
       context: ./fcrepo/4.7.5
-    image: oapass/fcrepo:4.7.5-3.4-1@sha256:56faf95a9753f2548665de0154888221a7c02ae2158489d08ec5499ed7ceb3fd
+    image: oapass/fcrepo:4.7.5-3.4-2@sha256:581f71675a1adab1568ea1924f8a83df974b228c3fd6181f83fbd157bab806d9
     container_name: fcrepo
     env_file: .env
     ports:
@@ -118,7 +118,7 @@ services:
 
   sp:
     build: ./sp/2.6.1
-    image: oapass/sp:20190614
+    image: oapass/sp:20190614@sha256:a62e5e4db801bd9ca966eacece61e8e5f4b56df2f9a30d33a1484c28ce5b678e
     container_name: sp
     networks:
      - back
@@ -210,7 +210,7 @@ services:
 
   authz:
     build: ./authz
-    image: oapass/authz:0.4.4-3.4@sha256:a8f97298b613708775f22ad70a0dca59005d15143c77292533c51110933b7fde
+    image: oapass/authz:0.4.5-3.4@sha256:5ef2579e8094a3eb86d3765a6c910c8ce86a3a0352f821e751d647b4d97c5cc1
     container_name: authz
     env_file: .env
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,7 +118,7 @@ services:
 
   sp:
     build: ./sp/2.6.1
-    image: oapass/sp:201900508@sha256:94eb4796da7bed604468e295422be23c94f0119591fb37e11b40ce0376bca49f
+    image: oapass/sp:20190614
     container_name: sp
     networks:
      - back

--- a/fcrepo/4.7.5/Dockerfile
+++ b/fcrepo/4.7.5/Dockerfile
@@ -2,7 +2,7 @@ FROM tomcat:8.5.40-jre8-alpine@sha256:3bfda84777039e5150a74bfdff71979d1cb7106d74
 
 ENV FCREPO_VERSION=4.7.5 \
 JSONLD_ADDON_VERSION=0.0.6 \
-PASS_AUTHZ_VERSION=0.4.4 \
+PASS_AUTHZ_VERSION=0.4.5 \
 JMS_ADDON_VERSION=0.0.2 \
 FCREPO_HOME=${CATALINA_HOME}/fcrepo4-data \
 FCREPO_HOST=fcrepo \
@@ -73,15 +73,15 @@ RUN apk update && \
         | sha1sum -c -  && \
     wget -O ${CATALINA_HOME}/lib/pass-authz-core-${PASS_AUTHZ_VERSION}-shaded.jar \
         http://central.maven.org/maven2/org/dataconservancy/pass/pass-authz-core/${PASS_AUTHZ_VERSION}/pass-authz-core-${PASS_AUTHZ_VERSION}-shaded.jar && \
-    echo "622ad18d2f062e761426a5b0ec71f222794e5fbd *${CATALINA_HOME}/lib/pass-authz-core-${PASS_AUTHZ_VERSION}-shaded.jar" \
+    echo "c58879ab932a00931343d14ff8a517f1a4df35cb *${CATALINA_HOME}/lib/pass-authz-core-${PASS_AUTHZ_VERSION}-shaded.jar" \
        | sha1sum -c -  && \
     wget -O ${CATALINA_HOME}/lib/pass-authz-roles-${PASS_AUTHZ_VERSION}.jar \
         http://central.maven.org/maven2/org/dataconservancy/pass/pass-authz-roles/${PASS_AUTHZ_VERSION}/pass-authz-roles-${PASS_AUTHZ_VERSION}.jar && \
-    echo "671c6f3d086124f2033ac51794d95a250a222d28 *${CATALINA_HOME}/lib/pass-authz-roles-${PASS_AUTHZ_VERSION}.jar" \
+    echo "d37aacea30dc94794f18cf4178f8400f4d1ddd38 *${CATALINA_HOME}/lib/pass-authz-roles-${PASS_AUTHZ_VERSION}.jar" \
         | sha1sum -c -  && \
     wget -O ${CATALINA_HOME}/webapps/pass-user-service.war \
         http://central.maven.org/maven2/org/dataconservancy/pass/pass-user-service/${PASS_AUTHZ_VERSION}/pass-user-service-${PASS_AUTHZ_VERSION}.war && \
-    echo "48c13c3848d0b50370cdedb8fbcd0c5d3816199d *${CATALINA_HOME}/webapps/pass-user-service.war" \
+    echo "3b7b1a97da36de29924d02da860c32c35ed4ccaf *${CATALINA_HOME}/webapps/pass-user-service.war" \
         | sha1sum -c -  && \
     mkdir ${CATALINA_HOME}/webapps/pass-user-service && \
     unzip ${CATALINA_HOME}/webapps/pass-user-service.war -d ${CATALINA_HOME}/webapps/pass-user-service  && \

--- a/sp/2.6.1/etc-shibboleth/attribute-map.xml
+++ b/sp/2.6.1/etc-shibboleth/attribute-map.xml
@@ -84,8 +84,8 @@
     <!-- Examples of LDAP-based attributes, uncomment to use these... -->
     
     <Attribute name="urn:mace:dir:attribute-def:cn" id="cn"/>
-    <Attribute name="urn:mace:dir:attribute-def:sn" id="sn"/>
-    <Attribute name="urn:mace:dir:attribute-def:givenName" id="givenName"/>
+    <Attribute name="urn:mace:dir:attribute-def:sn" id="Sn"/>
+    <Attribute name="urn:mace:dir:attribute-def:givenName" id="Givenname"/>
     <Attribute name="urn:mace:dir:attribute-def:displayName" id="displayName"/>
     <Attribute name="urn:mace:dir:attribute-def:uid" id="uid"/>
     <Attribute name="urn:mace:dir:attribute-def:mail" id="mail"/>
@@ -112,8 +112,8 @@
     <Attribute name="urn:mace:dir:attribute-def:physicalDeliveryOfficeName" id="physicalDeliveryOfficeName"/>
 
     <Attribute name="urn:oid:2.5.4.3" id="cn"/>
-    <Attribute name="urn:oid:2.5.4.4" id="sn"/>
-    <Attribute name="urn:oid:2.5.4.42" id="givenName"/>
+    <Attribute name="urn:oid:2.5.4.4" id="Sn"/>
+    <Attribute name="urn:oid:2.5.4.42" id="Givenname"/>
     <Attribute name="urn:oid:2.16.840.1.113730.3.1.241" id="Displayname"/>
     <Attribute name="urn:oid:0.9.2342.19200300.100.1.1" id="uid"/>
     <Attribute name="urn:oid:0.9.2342.19200300.100.1.3" id="Mail"/>


### PR DESCRIPTION
## About
Updates the Shibboleth SP image, mapping the `sn` and `givenName` attribute names to `Sn` and `Givenname` respectively.  Those are the attribute names expected by the pass-authz `ShibAuthUserProvider`

Updates the `authz` and `fcrepo` images to use the `0.4.5` release of `pass-authz`.

## Testing
1. *Before* checking out this PR, start pass-docker from the `master` branch.  
2. Do *not* login to PASS normally.
3. Wait for Fedora to start completely (docker logs -f fcrepo)
4. Open an incognito browser, and visit https://pass.local/pass-user-service/whoami
5. When prompted, login as `newSubmitter5`, password `moo`.  Prior to logging in, this person does not have a `User` resource in PASS.  By logging in, the pass-user-service will *create* a `User` for `newSubmitter5`.
6. Inspect the resulting JSON, and insure that `firstName` and `lastName` are `null`.

Stop docker, remove containers.

1. Check out this PR
1. Run `docker-compose pull` (new `fcrepo` and `authz` images should be downloaded)
1. Start docker (`docker-compose up -d`)
2. Follow the same steps above, waiting for fcrepo then directly visit https://pass.local/pass-user-service/whoami without logging into PASS normally.  Login as `newSubmitter5`, password `moo`
3. Inspect the resulting JSON, and insure that `firstName` and `lastName` are *not* `null`
