### PR TITLE
Support Harvard DASH metadata elements for DSpace image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,7 +127,7 @@ services:
 
   dspace:
     build: ./dspace/6.2
-    image: oapass/dspace@sha256:ead59d2f598fd04e28e381448f9128a72def497e351124f74b78cf3ac9de757a
+    image: oapass/dspace:20190624@sha256:db7a4fe9e2b0a261881a368a5ad43fab82a77a6fc66e95ab56f5f8b0bf6d21fe
     container_name: dspace
     env_file: .env
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,7 +127,7 @@ services:
 
   dspace:
     build: ./dspace/6.2
-    image: oapass/dspace:20190705@sha256:fa645183d13e1f59c1f4d6dde9ffc2a894240510a64a978b5ef58bfeb26dded4
+    image: oapass/dspace:20190705
     container_name: dspace
     env_file: .env
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,7 +127,7 @@ services:
 
   dspace:
     build: ./dspace/6.2
-    image: oapass/dspace:20190730
+    image: oapass/dspace:20190730@sha256:6fe25b4e902a23c0a5e5e878e7764499e31d4280b68df273d7d0bd5172dfbe22
     container_name: dspace
     env_file: .env
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,7 +127,7 @@ services:
 
   dspace:
     build: ./dspace/6.2
-    image: oapass/dspace:20190705
+    image: oapass/dspace:20190730
     container_name: dspace
     env_file: .env
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,7 +127,7 @@ services:
 
   dspace:
     build: ./dspace/6.2
-    image: oapass/dspace:20190624@sha256:db7a4fe9e2b0a261881a368a5ad43fab82a77a6fc66e95ab56f5f8b0bf6d21fe
+    image: oapass/dspace:20190705@sha256:fa645183d13e1f59c1f4d6dde9ffc2a894240510a64a978b5ef58bfeb26dded4
     container_name: dspace
     env_file: .env
     ports:

--- a/dspace/6.2/import.xml
+++ b/dspace/6.2/import.xml
@@ -21,5 +21,9 @@
       <name>Collection One</name>
       <description>A Collection used for testing, populated by Docker</description>
     </collection>
+    <collection>
+      <name>Collection Two</name>
+      <description>A Collection used for testing workflow-based submissions</description>
+    </collection>
   </community>
 </import_structure>

--- a/dspace/6.2/wait-and-init-db.sh
+++ b/dspace/6.2/wait-and-init-db.sh
@@ -231,7 +231,8 @@ function lookup_eperson_uuid_for_name() {
 }
 
 
-# Create EGroup COLLECTION_${COLLECTION_TWO_UUID}_WORKFLOW_STEP_2, and allow members to submit to Collection Two
+# Create EGroups COLLECTION_${COLLECTION_TWO_UUID}_WORKFLOW_STEP_2, and COLLECTION_${COLLECTION_TWO_UUID}_SUBMIT, and
+# allow members to approve and submit to Collection Two.
 function update_policies() {
     (>&2 echo ">>> Updating resource policies ...")
 
@@ -279,14 +280,15 @@ function update_policies() {
     perform_query "INSERT INTO epersongroup2eperson VALUES ('${SUBMIT_GROUP_UUID}', '${SUBMITTER_UUID}')"
     perform_query "INSERT INTO epersongroup2eperson VALUES ('${SUBMIT_GROUP_UUID}', '${ADMIN_UUID}')"
 
-    # anonymous group may submit to collection 2
+    # submit group may submit to collection 2
     perform_query "INSERT INTO ${RESOURCE_POLICY_TABLE} (policy_id, resource_type_id, action_id, epersongroup_id, dspace_object) VALUES (nextval('${RESOURCE_POLICY_SEQ}'), '${RESOURCE_TYPE}', '${ADD_ACTION}', '${SUBMIT_GROUP_UUID}', '${COLLECTION_TWO_UUID}')"
 
-    # admin group may edit/update/approve/reject submissions to collection 2
+    # workflow group may edit/update/approve/reject submissions to collection 2
     perform_query "INSERT INTO ${RESOURCE_POLICY_TABLE} (policy_id, resource_type_id, action_id, rptype, epersongroup_id, dspace_object) VALUES (nextval('${RESOURCE_POLICY_SEQ}'), '${RESOURCE_TYPE}', '${ADD_ACTION}', '${RPTYPE}', '${APPROVE_WORKFLOW_UUID}', '${COLLECTION_TWO_UUID}')"
 
     perform_query "INSERT INTO ${RESOURCE_POLICY_TABLE} (policy_id, resource_type_id, action_id, rptype, epersongroup_id, dspace_object) VALUES (nextval('${RESOURCE_POLICY_SEQ}'), '${RESOURCE_TYPE}', '${XXX_ACTION}', '${RPTYPE}', '${APPROVE_WORKFLOW_UUID}', '${COLLECTION_TWO_UUID}')"
 
+    # Attach the workflow and submit groups to Collection 2
     perform_query "UPDATE ${COLLECTION_TABLE} SET workflow_step_2 = '${APPROVE_WORKFLOW_UUID}', submitter = '${SUBMIT_GROUP_UUID}' WHERE uuid='${COLLECTION_TWO_UUID}'"
 }
 
@@ -316,8 +318,8 @@ import_communities_and_collections
 # Create a user for creating submissions who doesn't have admin privileges
 create_submitter_user
 
-# Allow uses of the Anonymous group to submit to Collection 2
-# Allow Administrator group to approve submissions to Collection 2
+# Create a group that includes the Submitter; allow this group to deposit submissions to Collection 2
+# Create a group that includes the Administrator; allow this group to approve submissions to Collection 2
 update_policies
 
 # Create local metadata schema used to carry embargo metadata fields

--- a/dspace/6.2/wait-and-init-db.sh
+++ b/dspace/6.2/wait-and-init-db.sh
@@ -222,6 +222,7 @@ function update_policies() {
     local XXX_ACTION=6 # unknown, but has to do with approving a submission
     local RPTYPE="TYPE_WORKFLOW"
     local RESOURCE_POLICY_TABLE=resourcepolicy
+    local RESOURCE_POLICY_SEQ=resourcepolicy_seq
 
     lookup_collection_uuid_for_handle "123456789/3"
     local COLLECTION_TWO_UUID=${UUID}
@@ -232,12 +233,12 @@ function update_policies() {
     local ADMIN_GROUP_UUID=${UUID}
 
     # anonymous group may submit to collection 2
-    perform_query "INSERT INTO ${RESOURCE_POLICY_TABLE} (policy_id, resource_type_id, action_id, epersongroup_id, dspace_object) VALUES (10, '${RESOURCE_TYPE}', '${ADD_ACTION}', '${ANONYMOUS_GROUP_UUID}', '${COLLECTION_TWO_UUID}')"
+    perform_query "INSERT INTO ${RESOURCE_POLICY_TABLE} (policy_id, resource_type_id, action_id, epersongroup_id, dspace_object) VALUES (nextval('${RESOURCE_POLICY_SEQ}'), '${RESOURCE_TYPE}', '${ADD_ACTION}', '${ANONYMOUS_GROUP_UUID}', '${COLLECTION_TWO_UUID}')"
 
     # admin group may edit/update/approve/reject submissions to collection 2
-    perform_query "INSERT INTO ${RESOURCE_POLICY_TABLE} (policy_id, resource_type_id, action_id, rptype, epersongroup_id, dspace_object) VALUES (11, '${RESOURCE_TYPE}', '${ADD_ACTION}', '${RPTYPE}', '${ADMIN_GROUP_UUID}', '${COLLECTION_TWO_UUID}')"
+    perform_query "INSERT INTO ${RESOURCE_POLICY_TABLE} (policy_id, resource_type_id, action_id, rptype, epersongroup_id, dspace_object) VALUES (nextval('${RESOURCE_POLICY_SEQ}'), '${RESOURCE_TYPE}', '${ADD_ACTION}', '${RPTYPE}', '${ADMIN_GROUP_UUID}', '${COLLECTION_TWO_UUID}')"
 
-    perform_query "INSERT INTO ${RESOURCE_POLICY_TABLE} (policy_id, resource_type_id, action_id, rptype, epersongroup_id, dspace_object) VALUES (12, '${RESOURCE_TYPE}', '${XXX_ACTION}', '${RPTYPE}', '${ADMIN_GROUP_UUID}', '${COLLECTION_TWO_UUID}')"
+    perform_query "INSERT INTO ${RESOURCE_POLICY_TABLE} (policy_id, resource_type_id, action_id, rptype, epersongroup_id, dspace_object) VALUES (nextval('${RESOURCE_POLICY_SEQ}'), '${RESOURCE_TYPE}', '${XXX_ACTION}', '${RPTYPE}', '${ADMIN_GROUP_UUID}', '${COLLECTION_TWO_UUID}')"
 }
 
 # preserve WORKDIR


### PR DESCRIPTION
Update the Docker DSpace instance to support Harvard DASH metadata schema elements and collection workflows.

Adds DASH metadata schema to DSpace, supporting
* dash.funder.award
* dash.funder.identifier
* dash.funder.name

Updates DC schema, supporting
* dc.identifier.doi
* dc.source.journal
* dc.source.volume

Incoming SWORD packages with these metadata elements present will be mapped into the DSpace Item metadata, and presenting on the Item splash page.

Adds a second collection (Collection 2) to DSpace, which enables workflows.  The user `submitter@oapass.org` (password `moo`) can submit to Collection 2.  The administrator must manually login and approve the submission before it is assigned a handle and becomes the member of the collection.

Tags the image with a date convention and hash.

*N.B.* this PR should be *squashed*