### PR TITLE
Update schema service to no longer have required label for orcid

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -248,7 +248,7 @@ services:
       - PASS_NOTIFICATION_CONFIGURATION=file:/notification.json
 
   schemaservice:
-    image: oapass/schema-service:v0.3.1@sha256:9276b5262e964f19ee0bc9be9eedb82c237349afe6d934ba84b5a152bab44bc5
+    image: oapass/schema-service:v0.4.0@sha256:f6662809566184c9332d394465bea2cf93080aa018cf8ef322d0d6cb99982f17
     container_name: schemaservice
     env_file: .env
     ports:


### PR DESCRIPTION
To test, load up the UI, login as `nih-user` and start a new submission using a DOI like `10.1039/c7an01256j` to make things slightly easier. Progress through the workflow. When you get to the metadata forms in Step 5, verify that the author orcid input does not have `(required)` in its label

See https://github.com/OA-PASS/pass-ember/issues/958