### PR TITLE
Release Deposit Services 1.0.0-3.4

### DIFF
--- a/deposit-services/1.0.0-3.4/Dockerfile
+++ b/deposit-services/1.0.0-3.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM oapass/deposit-services-providers:0.0.1-SNAPSHOT@sha256:4232da6aebefade8d7ef14a254cf29c5c08adae36bc3d66121c292c6be584ad0
+FROM oapass/deposit-services-providers:0.0.1@sha256:15efaa68fdabe8c3df6438fbff5e0a38bad5132a2844a9c320b95d5fdb6be5c7
 
 RUN touch /repositories.json
 

--- a/deposit-services/1.0.0-3.4/README.md
+++ b/deposit-services/1.0.0-3.4/README.md
@@ -1,4 +1,17 @@
-# Deposit Services Docker Images
+# Deposit Services
+
+## Version 1.1.0-3.4
+
+Version 1.1.0-3.4 is the first release of Deposit Services that utilizes Package Providers.  It supports version [3.4][13] of the JSON-LD context (uses [version 0.6.0 of the PASS Java Client][14])
+
+Includes the following package providers (version [0.0.1][12]):
+- [JScholarship][9]
+- [NIH (a.k.a PMC)][10]
+- [BagIt][11]
+
+The runtime configuration file included in this image configures JScholarship and NIH (PMC).  
+
+## Docker Images
 
 Deposit Services is composed of a hierarchy of images:
 
@@ -74,3 +87,9 @@ Next, `jhu-package-providers` is released with the `maven-release-plugin`, and d
 [6]: ./repositories.json
 [7]: https://github.com/OA-PASS/deposit-services/blob/master/.travis.yml#L30
 [8]: https://github.com/OA-PASS/deposit-services/blob/master/trigger-dependent-build
+[9]: https://github.com/OA-PASS/jhu-package-providers/tree/0.0.1/jscholarship-package-provider
+[10]: https://github.com/OA-PASS/jhu-package-providers/tree/0.0.1/nihms-package-provider
+[11]: https://github.com/OA-PASS/jhu-package-providers/tree/0.0.1/bagit-package-provider
+[12]: https://github.com/OA-PASS/jhu-package-providers/tree/0.0.1/
+[13]: https://github.com/OA-PASS/pass-data-model/blob/master/src/main/resources/context-3.4.jsonld
+[14]: https://github.com/OA-PASS/java-fedora-client/tree/0.6.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -192,7 +192,7 @@ services:
 
   deposit:
     build: ./deposit-services/1.0.0-3.4
-    image: oapass/deposit-pass-docker:1.0.0-3.4-SNAPSHOT@sha256:299e8c6bb8a861e2147f13d728fee898e61d2be5554ae405d8ddb29b50419fe8
+    image: oapass/deposit-pass-docker:1.0.0-3.4sha256@:8a2a02f0f3d58a10d4b46ced70ba53e267d4077bb7f7c29d780a9aaeab73b076
     container_name: deposit
     env_file: .env
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -192,7 +192,7 @@ services:
 
   deposit:
     build: ./deposit-services/1.0.0-3.4
-    image: oapass/deposit-pass-docker:1.0.0-3.4sha256@:8a2a02f0f3d58a10d4b46ced70ba53e267d4077bb7f7c29d780a9aaeab73b076
+    image: oapass/deposit-pass-docker:1.0.0-3.4@sha256:8a2a02f0f3d58a10d4b46ced70ba53e267d4077bb7f7c29d780a9aaeab73b076
     container_name: deposit
     env_file: .env
     environment:


### PR DESCRIPTION
- Supports CMF rollout
- First release based on package providers (oapass/deposit-services-providers:0.0.1@sha256:15efaa6)
- Updated README