### PR TITLE
Some schema service updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ A [full](https://github.com/OA-PASS/deposit-services#production-configuration-va
 - PASS_FEDORA_USER:  Username for basic auth to Fedora (default: "fedoraAdmin")
 - PASS_FEDORA_PASSWORD: Password for basic auth to Fedora (default: "moo")
 - SCHEMA_SERVICE_PORT: The port the schema service is served on (default: `8086`)
+- SCHEMA_SERVICE_MERGE: (OPTIONAL) (boolean) If this parameter is specified and set to `true` then all responses made by the schema service will merge all resulting schemas into a single schema.
 
 ### DOI service variables
 The service will look for an environment variable called PASS_DOI_SERVICE_MAILTO to specify a value on the User-Agent header on the Crossref request. If not present, the default is pass@jhu.edu. The service will require the following environment variables for the java client for Fedora if the defaults are not to be used:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -248,7 +248,7 @@ services:
       - PASS_NOTIFICATION_CONFIGURATION=file:/notification.json
 
   schemaservice:
-    image: oapass/schema-service:v0.3.1@sha256:9276b5262e964f19ee0bc9be9eedb82c237349afe6d934ba84b5a152bab44bc5
+    image: oapass/schema-service:v0.5.0@sha256:98c6bc91a4660746d8eda54f4d410f402e161429817284722c407a2b253ee7e8
     container_name: schemaservice
     env_file: .env
     ports:


### PR DESCRIPTION
This PR ends up combining a couple of updates to the schema service that have not yet been merged here.

* Validation rules for `authors`, `author`, and `orcid` fields changed
* Add ability to merge multiple schemas into one. This can be done globally by setting an environment variable (`SCHEMA_SERVICE_MERGE=true`) or on a per-request basis
  * An upcoming `pass-ember` update will use the per-request method of getting merged schemas