### PR TITLE
Bump schema service to v0.6.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -248,7 +248,7 @@ services:
       - PASS_NOTIFICATION_CONFIGURATION=file:/notification.json
 
   schemaservice:
-    image: oapass/schema-service:v0.5.2@sha256:572dcfe965c5588564de22accd1ecaca3d3b141ba1097c9830026420ca3557c4
+    image: oapass/schema-service:v0.6.0@sha256:0076f00bfa55dc1818d20859efca2e119e2bf23eb3972bd2cac7200a9dcd8844
     container_name: schemaservice
     env_file: .env
     ports:


### PR DESCRIPTION
This includes support for Harvard schemas, and has been tested separately in OA-PASS/metadata-schemas#36

For the sake of this PR, just make sure there is nothing broken as far as JHU is concerned.

Resolves OA-PASS/metadata-schemas#39