### PR TITLE
Branding support

### DIFF
--- a/.env
+++ b/.env
@@ -17,14 +17,14 @@ STATIC_HTML_PORT=82
 
 # Static html server build-time config
 STATIC_HTML_GIT_REPO=https://github.com/OA-PASS/pass-ui-static.git
-STATIC_HTML_GIT_BRANCH=c035da4d19bb6d6ab45424abe732900008d41bce
+STATIC_HTML_GIT_BRANCH=bad963dfe8135b6257dd099b201aaebdbb59daff
 
 # Ember app runtime config
 EMBER_PORT=81
 
 # Ember app build-time config
 EMBER_GIT_REPO=https://github.com/OA-PASS/pass-ember
-EMBER_GIT_BRANCH=1336ca1920c5ef8a8f589d525e61b7219648d369
+EMBER_GIT_BRANCH=25a682c28aadea51da9d00e07fc01ade4640f723
 
 EMBER_ROOT_URL=/app/
 

--- a/.env
+++ b/.env
@@ -16,7 +16,7 @@ STATIC_HTML_PORT=82
 
 # Static html server build-time config
 STATIC_HTML_GIT_REPO=https://github.com/OA-PASS/pass-ui-static.git
-STATIC_HTML_GIT_BRANCH=4ab9eb389c0ebfaac99a697056b7e3b3559bdd91
+STATIC_HTML_GIT_BRANCH=8f52cd7adb7cd4d7912d921b414e9a85b1263cdb
 
 # Ember app runtime config
 EMBER_PORT=81

--- a/.env
+++ b/.env
@@ -12,6 +12,7 @@ FTP_PASS=nihmsftppass
 #FTP_PASS=<password>
 
 # Static html server runtime config
+STATIC_CONFIG_URI=/config.json
 STATIC_HTML_PORT=82
 
 # Static html server build-time config

--- a/.env
+++ b/.env
@@ -17,7 +17,7 @@ STATIC_HTML_PORT=82
 
 # Static html server build-time config
 STATIC_HTML_GIT_REPO=https://github.com/OA-PASS/pass-ui-static.git
-STATIC_HTML_GIT_BRANCH=62afb7e4846f5fcefef15cdcd5ecd477ba7e9d51
+STATIC_HTML_GIT_BRANCH=c035da4d19bb6d6ab45424abe732900008d41bce
 
 # Ember app runtime config
 EMBER_PORT=81

--- a/.env
+++ b/.env
@@ -17,7 +17,7 @@ STATIC_HTML_PORT=82
 
 # Static html server build-time config
 STATIC_HTML_GIT_REPO=https://github.com/OA-PASS/pass-ui-static.git
-STATIC_HTML_GIT_BRANCH=8f52cd7adb7cd4d7912d921b414e9a85b1263cdb
+STATIC_HTML_GIT_BRANCH=62afb7e4846f5fcefef15cdcd5ecd477ba7e9d51
 
 # Ember app runtime config
 EMBER_PORT=81

--- a/.env
+++ b/.env
@@ -24,7 +24,7 @@ EMBER_PORT=81
 
 # Ember app build-time config
 EMBER_GIT_REPO=https://github.com/OA-PASS/pass-ember
-EMBER_GIT_BRANCH=0c1a7e971847cc4b2f1a96b3afa5f8f5e835f460
+EMBER_GIT_BRANCH=1336ca1920c5ef8a8f589d525e61b7219648d369
 
 EMBER_ROOT_URL=/app/
 

--- a/README.md
+++ b/README.md
@@ -33,12 +33,15 @@ To configure the Docker images, open up the `.env` file and make any necessary c
 
 ### Ember application-related variables
 
+It is important to note that the Ember application does not actually read environment variables at runtime. Instead, values for environment variables are baked into the Ember app at during the build. Ember will actually embed its environment context into the application's HTML by adding it to the rendered document `<head>`. This means that in order to change any variable that the Ember app relies on, you will need to rebuild the app and create a new Docker image.
+
   - EMBER_PORT: the Ember HTTP application is served on this port
   - The Ember code base will be downloaded and built from `EMBER_GIT_REPO`, using the branch or tag defined in `EMBER_GIT_BRANCH`
   - DOI_SERVICE_URL: The relative URL of the DOI service, used at `ember` image _build time_, not run time (default: `/doiservice/journal`)
   - POLICY_SERVICE_URL: The relative URL of the schema service, used at `ember` image _build time_, not run time (default: `/policyservice`)
   - USER_SERVICE_URL: The relative URL of the user service, used at `ember` image _build time_, not run time (default: `/pass-user-service/whoami`)
   - METADATA_SCHEMA_URI: URL to the metadata global schema. Gets added to metadata blob (default: `https://oa-pass.github.io/metadata-schemas/jhu/global.json`)
+  - STATIC_CONFIG_URI: The relative URI of the static branding configuration file. This is important to allow the Ember app to be able to retrieve branding stylesheets, images, and other static assets. (_default: `/config.json`_)
 
 
 ### Fedora-related variables

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
       args:
         STATIC_HTML_GIT_REPO: "${STATIC_HTML_GIT_REPO}"
         STATIC_HTML_GIT_BRANCH: "${STATIC_HTML_GIT_BRANCH}"
-    image: oapass/static-html:20190815-8f52cd7@sha256:38b55bb2d2856d1b11a00a8897bb473059b90761385ed5580b04f10813c4346b
+    image: oapass/static-html:20190820-62afb7e@sha256:790f80c75e96974390e241075c4e1510d0d43d740877c1e40fefc3e144737f42
     container_name: static-html
     env_file: .env
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
         USER_SERVICE_URL: "${USER_SERVICE_URL}"
         DOI_SERVICE_URL: "${DOI_SERVICE_URL}"
         METADATA_SCHEMA_URI: "${METADATA_SCHEMA_URI}"
-    image: oapass/ember:20190815-1336ca1@sha256:0d1aa991e0e65415acb6474914b68dd9ae9c5b8b90e326ae5db9d76622d8d5fc
+    image: oapass/ember:20190822-25a682c@sha256:602c72b66a5d018171bd402980e36fa90c7b11e21a1af2446e782c6a19a58fc4
     container_name: ember
     env_file: .env
     networks:
@@ -56,7 +56,7 @@ services:
       args:
         STATIC_HTML_GIT_REPO: "${STATIC_HTML_GIT_REPO}"
         STATIC_HTML_GIT_BRANCH: "${STATIC_HTML_GIT_BRANCH}"
-    image: oapass/static-html:20190820-c035da4@sha256:223bb489ac94517788be149bef69c40d65e715ff11957833e57ded0b2d5fd023
+    image: oapass/static-html:20190822-bad963d@sha256:181a4b8bc0e5e4c69fa9ed37f2ec9d0192f628614656ebab40cd471334ed4aba
     container_name: static-html
     env_file: .env
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
         USER_SERVICE_URL: "${USER_SERVICE_URL}"
         DOI_SERVICE_URL: "${DOI_SERVICE_URL}"
         METADATA_SCHEMA_URI: "${METADATA_SCHEMA_URI}"
-    image: oapass/ember:mootest
+    image: oapass/ember:20190815-1336ca1@sha256:0d1aa991e0e65415acb6474914b68dd9ae9c5b8b90e326ae5db9d76622d8d5fc
     container_name: ember
     env_file: .env
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
       args:
         STATIC_HTML_GIT_REPO: "${STATIC_HTML_GIT_REPO}"
         STATIC_HTML_GIT_BRANCH: "${STATIC_HTML_GIT_BRANCH}"
-    image: oapass/static-html:20181116-4ab9eb3@sha256:2c5a8f315783ab41205aaead6c82c6148f9d6334b1dc33b7bf31033cf008d2d6
+    image: oapass/static-html:20190815-8f52cd7@sha256:38b55bb2d2856d1b11a00a8897bb473059b90761385ed5580b04f10813c4346b
     container_name: static-html
     env_file: .env
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
       args:
         STATIC_HTML_GIT_REPO: "${STATIC_HTML_GIT_REPO}"
         STATIC_HTML_GIT_BRANCH: "${STATIC_HTML_GIT_BRANCH}"
-    image: oapass/static-html:20190820-62afb7e@sha256:790f80c75e96974390e241075c4e1510d0d43d740877c1e40fefc3e144737f42
+    image: oapass/static-html:20190820-c035da4@sha256:223bb489ac94517788be149bef69c40d65e715ff11957833e57ded0b2d5fd023
     container_name: static-html
     env_file: .env
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
         USER_SERVICE_URL: "${USER_SERVICE_URL}"
         DOI_SERVICE_URL: "${DOI_SERVICE_URL}"
         METADATA_SCHEMA_URI: "${METADATA_SCHEMA_URI}"
-    image: oapass/ember:20190730-0c1a7e9@sha256:42241712789783d48a4eed0d2c6f99193822c571742e6d30c2744f02e58bb9aa
+    image: oapass/ember:mootest
     container_name: ember
     env_file: .env
     networks:


### PR DESCRIPTION
This PR will add branding support for the PASS UI.

- Branding related assets moved out of the Ember app where possible, including some CSS and static pages
- `static-html` updated to more closely match the HTML structure of the updated `pass-ember`
- `static-html` now defines a configuration file (`config.json`) that Ember can load in order to know where to find various assets, which should give more flexibility in defining a new 'brand'

The changes necessary for defining a new "brand" for PASS should now be limited to modifying `static-html`. This also means that in order to switch "brands" in the UI, we only need to swap out the Docker image for `static-html`. The simplest way of creating these new images would be to make modifications to either a new branch or new fork of `pass-ui-static` and using the already established methods of creating the Docker images.

A lot of HTML was consolidated and various Ember specific element IDs were removed from the static pages. 

### Change from production

You will notice some changes to colors in the UI with this PR compared to production. The only noticeable such change is the blue header was changed to a slightly darker blue to better follow the JHU branding guidelines. **Let me know if this is a problem and I can change it back**

### Testing

We basically need to ensure that this version functions exactly the same as production

```
docker-compose pull fcrepo activemq ember static-html proxy idp ldap sp indexer elasticsearch assets authz schemaservice policyservice doiservice
docker-compose up -d fcrepo activemq ember static-html proxy idp ldap sp indexer elasticsearch assets authz schemaservice policyservice doiservice
docker-compose logs -f
```