### PR TITLE
Update ASPR logo in Harvard static pages

### DIFF
--- a/harvard.yml
+++ b/harvard.yml
@@ -55,8 +55,8 @@ services:
       context: ./static-html
       args:
         STATIC_HTML_GIT_REPO: "https://github.com/OA-PASS/pass-ui-static.git"
-        STATIC_HTML_GIT_BRANCH: "a1fdd8fca69f25900992b583c08e89d1f3432e87"
-    image: oapass/static-html:harvard-v0.1.1-a1fdd8@sha256:728ff6b5ec6422fece7ca488bd506363824ca11554926c1e194cde2b55d18821
+        STATIC_HTML_GIT_BRANCH: "35d5c9f118f3045f387f8490eacec4388f3ba430"
+    image: oapass/static-html:harvard-v0.1.2-35d5c9@sha256:60b5530152aa6fd9d04951e8cc01eb456172aa48a390ed05d9caa7cc0455a903
     container_name: static-html
     env_file: .harvard_env
     ports:


### PR DESCRIPTION
https://github.com/OA-PASS/pass-ui-static/issues/29 for details

The ASPR logo needs to be updated.

## Testing

We only need to check the logo on the PASS homepage. For this, we only need to boot up `proxy` and `static-html` images.

```
docker-compose -f harvard.yml pull proxy static-html
docker-compose -f harvard.yml up -d proxy static-html
docker-compose logs -f
```

The images should boot up very quickly. Once things have settled, navigate to **`https://pass.local`** to see the PASS landing page. The ASPR logo will be the 2nd logo in rotation on the far bottom right. We need to make sure it matches the "correct" logo as noted in the ticket linked above.