### PR TITLE
Amq password breakout

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To configure the Docker images, open up the `.env` file and make any necessary c
 
 ### Ember application-related variables
 
-It is important to note that the Ember application does not actually read environment variables at runtime. Instead, values for environment variables are baked into the Ember app at during the build. Ember will actually embed its environment context into the application's HTML by adding it to the rendered document `<head>`. This means that in order to change any variable that the Ember app relies on, you will need to rebuild the app and create a new Docker imafge.
+It is important to note that the Ember application does not actually read environment variables at runtime. Instead, values for environment variables are baked into the Ember app at during the build. Ember will actually embed its environment context into the application's HTML by adding it to the rendered document `<head>`. This means that in order to change any variable that the Ember app relies on, you will need to rebuild the app and create a new Docker image.
 
   - EMBER_PORT: the Ember HTTP application is served on this port
   - The Ember code base will be downloaded and built from `EMBER_GIT_REPO`, using the branch or tag defined in `EMBER_GIT_BRANCH`

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To configure the Docker images, open up the `.env` file and make any necessary c
 
 ### Ember application-related variables
 
-It is important to note that the Ember application does not actually read environment variables at runtime. Instead, values for environment variables are baked into the Ember app at during the build. Ember will actually embed its environment context into the application's HTML by adding it to the rendered document `<head>`. This means that in order to change any variable that the Ember app relies on, you will need to rebuild the app and create a new Docker image.
+It is important to note that the Ember application does not actually read environment variables at runtime. Instead, values for environment variables are baked into the Ember app at during the build. Ember will actually embed its environment context into the application's HTML by adding it to the rendered document `<head>`. This means that in order to change any variable that the Ember app relies on, you will need to rebuild the app and create a new Docker imafge.
 
   - EMBER_PORT: the Ember HTTP application is served on this port
   - The Ember code base will be downloaded and built from `EMBER_GIT_REPO`, using the branch or tag defined in `EMBER_GIT_BRANCH`
@@ -191,6 +191,8 @@ In addition we need PASS_EXTERNAL_FEDORA_BASEURL to be present to translate inte
 - `ACTIVEMQ_JMS_PORT` Openwire wire protocol (ActiveMQ native) port e.g. `61616`
 - `ACTIVEMQ_STOMP_PORT`= STOMP wire protocol (text-based) port e.g. `61613`
 - `ACTIVEMQ_WEBCONSOLE_PORT`= HTTP port for the ActiveMQ web console (admin/admin) e.g. `8161`
+- `ACTIVEMQ_USER`= Username for ActiveMQ clients (default `messaging`), will prefer SPRING_ACTIVEMQ_USER
+- `ACTIVEMQ_PASSWORD`=  Password for ActiveMQ clients (default `moo`), will prefer  SPRING_ACTIVEMQ_PASSWORD
 
 ### Mail-related variables
 

--- a/activemq/Dockerfile
+++ b/activemq/Dockerfile
@@ -1,13 +1,14 @@
 FROM openjdk:8-jre-alpine
 
-ENV ACTIVEMQ_VERSION 5.15.4
+ENV ACTIVEMQ_VERSION 5.15.11
 ENV ACTIVEMQ_DIST=apache-activemq-$ACTIVEMQ_VERSION \
     ACTIVEMQ_JMS_PORT=61616 \ 
     ACTIVEMQ_STOMP_PORT=61613 \ 
     ACTIVEMQ_WEBCONSOLE_PORT=8161 \
     ACTIVEMQ_HOME=/usr/local/activemq
 
-RUN  wget -O activemq.tar.gz \
+RUN apk add gettext && \ 
+    wget -O activemq.tar.gz \
         https://archive.apache.org/dist/activemq/${ACTIVEMQ_VERSION}/${ACTIVEMQ_DIST}-bin.tar.gz && \
     tar xzvf activemq.tar.gz -C  /usr/local && \
     ln -s /usr/local/$ACTIVEMQ_DIST $ACTIVEMQ_HOME && \
@@ -16,9 +17,13 @@ RUN  wget -O activemq.tar.gz \
     chown -h activemq:activemq ${ACTIVEMQ_HOME} && \
     rm activemq.tar.gz
 
+
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY activemq.xml /
+RUN chmod 0755 /usr/local/bin/entrypoint.sh
+
 WORKDIR $ACTIVEMQ_HOME
 USER activemq
 
-COPY activemq.xml conf/
-
-CMD ["/bin/sh", "-c", "bin/activemq console"]
+CMD ["/bin/sh", "-c", "/usr/local/bin/entrypoint.sh"]

--- a/activemq/activemq.xml
+++ b/activemq/activemq.xml
@@ -41,7 +41,7 @@
         <plugins>
             <simpleAuthenticationPlugin>
                 <users>
-                    <authenticationUser username="messaging" password="moo" groups="admins,producers,consumers" />
+                    <authenticationUser username="${ACTIVEMQ_USER}" password="${ACTIVEMQ_PASSWORD}" groups="admins,producers,consumers" />
                 </users>
             </simpleAuthenticationPlugin>
             <authorizationPlugin>

--- a/activemq/entrypoint.sh
+++ b/activemq/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# Set some defaults.  Either we use what was passed in ENV vars or use default hard-coded values
+# Then we set some variables to these values
+ACTIVEMQ_PASSWORD=${ACTIVEMQ_PASSWORD:=moo}
+ACTIVEMQ_USERNAME=${ACTIVEMQ_USER:=messaging}
+
+# For backwards compatibility:
+#   If SPRING_ACTIVEMQ* exist, use those. Otherwise use the defaults from above.
+export ACTIVEMQ_PASSWORD=${SPRING_ACTIVEMQ_PASSWORD:=$ACTIVEMQ_PASSWORD}
+export ACTIVEMQ_USER=${SPRING_ACTIVEMQ_USER:=$ACTIVEMQ_USER}
+
+envsubst '${ACTIVEMQ_PASSWORD}, ${ACTIVEMQ_USER}' < /activemq.xml > ${ACTIVEMQ_HOME}/conf/activemq.xml
+
+${ACTIVEMQ_HOME}/bin/activemq console

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
   activemq:
     build:
       context: ./activemq
-    image: oapass/activemq:20180618@sha256:e3cd47a1bc4c21899fc34e5ac7198f6c069f4148296bad0ce619cc2bdda5f435
+    image: oapass/activemq:20200219@sha256:e2351a4ce0d55fd7f016aeca37d789288dc8805fe8bf082b5ede28f7c18e5027
     container_name: activemq
     env_file: .env
     ports:


### PR DESCRIPTION
- Create a new entrypoint script
- Modify Dockerfile to add and call entrypoint
- Removed hardcoded username and password from activemq.xml
- Insert placeholders in activemq.xml for username and password

This setup willl use the default username of 'messaging' and the
password of 'moo' if no env vars are passed.

If SPRING_ACTIVEMQ_USER and SPRING_ACTIVEMQ_PASSWORD are
passed, these values will be used.  If not, it will look for
ACTIVEMQ_USER and ACTIVEMQ_PASSWORD and use those.

Otherwise, the default values are used.