### PR TITLE
Update static pages to remove licensed fonts

### DIFF
--- a/.env
+++ b/.env
@@ -17,7 +17,7 @@ STATIC_HTML_PORT=82
 
 # Static html server build-time config
 STATIC_HTML_GIT_REPO=https://github.com/OA-PASS/pass-ui-static.git
-STATIC_HTML_GIT_BRANCH=2f2f2ea332490d5331c2b9acbcbd26e850535ba7
+STATIC_HTML_GIT_BRANCH=3683b71cb95ba4208843c152754ad7443038d68a
 
 # Ember app runtime config
 EMBER_PORT=81

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
       args:
         STATIC_HTML_GIT_REPO: "${STATIC_HTML_GIT_REPO}"
         STATIC_HTML_GIT_BRANCH: "${STATIC_HTML_GIT_BRANCH}"
-    image: oapass/static-html:jhu-20220207-2f2f2ea@sha256:a2ec68690df85ebcc3e1b59195ea355a2eb96e0719f714448229936e8e81b59c
+    image: oapass/static-html:jhu-20220405-3683b71@sha256:sha256:004ee85541a607b17f0d20be56b1df9c99c954dc1c5b331b1325cc0b84a250c7
     container_name: static-html
     env_file: .env
     ports:


### PR DESCRIPTION
Maybe not strictly necessary before transferring our codebase, but this removes the licensed font files from the `static-html` image. Both the PASS static (public facing) pages and the PASS application will now render with browser default fonts.

The new image was pushed to Docker Hub, as we haven't yet started using the Github Container Registry. I don't expect this image to have a high number of download, so Docker Hub should be sufficient until we migrate our images to GHCR.

Related: https://github.com/OA-PASS/general-issues/issues/187